### PR TITLE
Opcode Decoding

### DIFF
--- a/feo3boy/src/bin/opcode-table.rs
+++ b/feo3boy/src/bin/opcode-table.rs
@@ -1,0 +1,18 @@
+//! Prints out all opcodes in a CSV table for comparison against published opcode tables.
+
+use feo3boy::gbz80core::opcode::Opcode;
+
+fn main() {
+    for l in 0u8..=0xF {
+        print!(",{:#04X}", l);
+    }
+    println!();
+    for h in (0u8..=0xFF).step_by(0x10) {
+        print!("{:#04X}", h);
+        for l in 0u8..=0xF {
+            let opcode = Opcode::decode(h + l);
+            print!(",\"{}\"", opcode);
+        }
+        println!();
+    }
+}

--- a/feo3boy/src/gbz80core.rs
+++ b/feo3boy/src/gbz80core.rs
@@ -2,6 +2,8 @@ use crate::memdev::MemDevice;
 
 use std::num::Wrapping;
 
+pub mod opcode;
+
 const FZERO: u8 = 0x80;
 const FSUB: u8 = 0x40;
 const FHALFCARRY: u8 = 0x20;

--- a/feo3boy/src/gbz80core.rs
+++ b/feo3boy/src/gbz80core.rs
@@ -80,7 +80,7 @@ impl Gbz80state {
 }
 
 pub fn tick(cpustate: &mut Gbz80state, mmu: &mut impl MemDevice) -> u64 {
-    println!("tick: pc @ 0x{:X}", cpustate.regs.pc);
+    println!("tick: pc @ {:#X}", cpustate.regs.pc);
     let opcode = pcload(cpustate, mmu);
     match dispatch(cpustate, mmu, opcode) {
         None => {

--- a/feo3boy/src/gbz80core.rs
+++ b/feo3boy/src/gbz80core.rs
@@ -84,7 +84,7 @@ pub fn tick(cpustate: &mut Gbz80state, mmu: &mut impl MemDevice) -> u64 {
     let opcode = pcload(cpustate, mmu);
     match dispatch(cpustate, mmu, opcode) {
         None => {
-            println!("Unknown opcode 0x{:X}. Skipping.", opcode);
+            println!("Unknown opcode {:#X}. Skipping.", opcode);
             0
         }
         Some((cycles, flags, flagmask)) => {

--- a/feo3boy/src/gbz80core.rs
+++ b/feo3boy/src/gbz80core.rs
@@ -80,11 +80,11 @@ impl Gbz80state {
 }
 
 pub fn tick(cpustate: &mut Gbz80state, mmu: &mut impl MemDevice) -> u64 {
-    println!("tick: pc @ {:#X}", cpustate.regs.pc);
+    println!("tick: pc @ {:#4X}", cpustate.regs.pc);
     let opcode = pcload(cpustate, mmu);
     match dispatch(cpustate, mmu, opcode) {
         None => {
-            println!("Unknown opcode {:#X}. Skipping.", opcode);
+            println!("Unknown opcode {:#4X}. Skipping.", opcode);
             0
         }
         Some((cycles, flags, flagmask)) => {

--- a/feo3boy/src/gbz80core.rs
+++ b/feo3boy/src/gbz80core.rs
@@ -80,11 +80,13 @@ impl Gbz80state {
 }
 
 pub fn tick(cpustate: &mut Gbz80state, mmu: &mut impl MemDevice) -> u64 {
-    println!("tick: pc @ {:#4X}", cpustate.regs.pc);
+    let expc = cpustate.regs.pc;
     let opcode = pcload(cpustate, mmu);
+    let decoded = opcode::Opcode::decode(opcode);
+    println!("tick: pc @ {:#06X}: {}", expc, decoded);
     match dispatch(cpustate, mmu, opcode) {
         None => {
-            println!("Unknown opcode {:#4X}. Skipping.", opcode);
+            println!("Unknown opcode {:#06X}. Skipping.", opcode);
             0
         }
         Some((cycles, flags, flagmask)) => {

--- a/feo3boy/src/gbz80core/opcode.rs
+++ b/feo3boy/src/gbz80core/opcode.rs
@@ -1,0 +1,368 @@
+use std::fmt;
+
+/// Parsed Opcode, not including any arguments that may be loaded from immediates, nor any follow-up
+/// ops if the operation is a prefixed op.
+#[derive(Copy, Clone, Debug)]
+pub enum Opcode {
+    /// No operation.
+    Nop,
+    /// Stop -- not sure what this does or how this differs from Halt.
+    Stop,
+    /// Relative jump. Load a signed immediate for the jump destination, then check the condition,
+    /// then jump if the condition is met.
+    JumpRelative(ConditionCode),
+    /// Increment the given 8 bit operand.
+    Inc8(Operand8),
+    /// Decrement the given 8 bit operand.
+    Dec8(Operand8),
+    /// Load a value from on 8 bit operand to another.
+    Load8 {
+        dest: Operand8,
+        source: Operand8,
+    },
+    /// Increment the given 16 bit operand.
+    Inc16(Operand16),
+    /// Decrement the given 16 bit operand.
+    Dec16(Operand16),
+    /// Load a 16 bit value from one operand to another.
+    Load16 {
+        dest: Operand16,
+        source: Operand16,
+    },
+    /// Add the given 16 bit operand to HL.
+    Add16(Operand16),
+    /// Halt instruction. Pauses but still accepts interrupts I think?
+    Halt,
+    /// Run the given operation on the ALU. The source is given by the operand, the destination is
+    /// always `A`, the accumulator register.
+    AluOp {
+        op: AluOp,
+        operand: Operand8,
+    },
+    PrefixCB,
+}
+
+impl Opcode {
+    /// Parse an opcode.
+    pub fn parse(opcode: u8) -> Self {
+        // Based on www.z80.info/decoding.htm, but adjusted based on codes which don't exist on the
+        // GB Z80.
+        let x = (opcode & 0b11000000) >> 6;
+        let p = (opcode & 0b00110000) >> 4;
+        let y = (opcode & 0b00111000) >> 3;
+        let q = (opcode & 0b00001000) != 0;
+        let z = opcode & 0b00000111;
+        match x {
+            0 => match z {
+                0 => match y {
+                    0 => Self::Nop,
+                    1 => unimplemented!(),
+                    2 => Self::Stop,
+                    code @ 3..=7 => Self::JumpRelative(ConditionCode::from_jrcode(code)),
+                    _ => unreachable!(),
+                },
+                1 => match q {
+                    false => Self::Load16 {
+                        dest: Operand16::from_pair_code_sp(p),
+                        source: Operand16::Immediate,
+                    },
+                    true => Self::Add16(Operand16::from_pair_code_sp(p)),
+                },
+                2 => match q {
+                    false => Self::Load8 {
+                        dest: Operand8::from_indirect(p),
+                        source: Operand8::A,
+                    },
+                    true => Self::Load8 {
+                        dest: Operand8::A,
+                        source: Operand8::from_indirect(p),
+                    },
+                },
+                3 => match q {
+                    false => Self::Inc16(Operand16::from_pair_code_sp(p)),
+                    true => Self::Dec16(Operand16::from_pair_code_sp(p)),
+                },
+                4 => Self::Inc8(Operand8::from_regcode(y)),
+                5 => Self::Dec8(Operand8::from_regcode(y)),
+                6 => Self::Load8 {
+                    dest: Operand8::from_regcode(y),
+                    source: Operand8::Immediate,
+                },
+                7 => unimplemented!(),
+                _ => unreachable!(),
+            },
+            1 => match (z, y) {
+                (6, 6) => Self::Halt,
+                _ => Self::Load8 {
+                    dest: Operand8::from_regcode(y),
+                    source: Operand8::from_regcode(z),
+                },
+            },
+            2 => Self::AluOp {
+                op: AluOp::from_ycode(y),
+                operand: Operand8::from_regcode(z),
+            },
+            3 => match z {
+                3 => match y {
+                    1 => Opcode::PrefixCB,
+                    0 | 2 | 3 | 4 | 5 | 6 | 7 => unimplemented!(),
+                    _ => unreachable!(),
+                },
+                6 => Self::AluOp {
+                    op: AluOp::from_ycode(y),
+                    operand: Operand8::Immediate,
+                },
+                0 | 1 | 2 | 4 | 5 | 7 => unimplemented!(),
+                _ => unreachable!(),
+            },
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl fmt::Display for Opcode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::Nop => f.write_str("NOP"),
+            Self::Stop => f.write_str("STOP"),
+            Self::JumpRelative(ConditionCode::Unconditional) => f.write_str("JR i8"),
+            Self::JumpRelative(code) => write!(f, "JR {},i8", code),
+            Self::Inc8(operand) => write!(f, "INC {}", operand),
+            Self::Dec8(operand) => write!(f, "DEC {}", operand),
+            Self::Load8 { dest, source } => write!(f, "LD {},{}", dest, source),
+            Self::Inc16(operand) => write!(f, "INC {}", operand),
+            Self::Dec16(operand) => write!(f, "DEC {}", operand),
+            Self::Load16 { dest, source } => write!(f, "LD {},{}", dest, source),
+            Self::Add16(operand) => write!(f, "ADD HL,{}", operand),
+            Self::Halt => f.write_str("HALT"),
+            Self::AluOp { op, operand } => write!(f, "{} A,{}", op, operand),
+            Self::PrefixCB => f.write_str("PREFIX CB"),
+        }
+    }
+}
+
+/// ALU Operation type.
+#[derive(Copy, Clone, Debug)]
+pub enum AluOp {
+    Add,
+    Adc,
+    Sub,
+    Sbc,
+    And,
+    Xor,
+    Or,
+    Cp,
+}
+
+impl AluOp {
+    /// Get the ALU operation type for the given opcode. Panics if the code is greater than 7.
+    fn from_ycode(code: u8) -> Self {
+        match code {
+            0 => Self::Add,
+            1 => Self::Adc,
+            2 => Self::Sub,
+            3 => Self::Sbc,
+            4 => Self::And,
+            5 => Self::Xor,
+            6 => Self::Or,
+            7 => Self::Cp,
+            _ => panic!("Unrecognized ALU operation type (y code) {}", code),
+        }
+    }
+}
+
+impl fmt::Display for AluOp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::Add => f.write_str("ADD"),
+            Self::Adc => f.write_str("ADC"),
+            Self::Sub => f.write_str("SUB"),
+            Self::Sbc => f.write_str("SBC"),
+            Self::And => f.write_str("AND"),
+            Self::Xor => f.write_str("XOR"),
+            Self::Or => f.write_str("OR"),
+            Self::Cp => f.write_str("CP"),
+        }
+    }
+}
+
+/// 8 bit operand. Either the source or destination of an 8 bit operation.
+#[derive(Copy, Clone, Debug)]
+pub enum Operand8 {
+    // 8 bit registers.
+    /// Normal register B.
+    B,
+    /// Normal register C.
+    C,
+    /// Normal register D.
+    D,
+    /// Normal register E.
+    E,
+    /// Normal register High.
+    H,
+    /// Normal register Low.
+    L,
+    /// Accumulator register.
+    A,
+    // Indirections of 16 bit register pairs.
+    /// Dereference HL.
+    AddrHL,
+    /// Dereference BC.
+    AddrBC,
+    /// Dereference DE.
+    AddrDE,
+    /// Dereference HL then increment HL.
+    AddrHLInc,
+    /// Dereference HL then decrement HL.
+    AddrHLDec,
+    /// Load value from immediate (and advance program counter). Cannot be used to store. Will
+    /// panic if used as the destination operand.
+    Immediate,
+    /// Dereference a 16 bit immediate value.
+    AddrImmediate,
+}
+
+impl Operand8 {
+    /// Get the 8 bit operand for the given register code. Panics if the code is greater than 7.
+    /// Note that register codes are mostly 8 bit registers but also include `(HL)`.
+    fn from_regcode(code: u8) -> Self {
+        match code {
+            0 => Self::B,
+            1 => Self::C,
+            2 => Self::D,
+            3 => Self::E,
+            4 => Self::H,
+            5 => Self::L,
+            6 => Self::AddrHL,
+            7 => Self::A,
+            _ => panic!("Unrecognized Operand type {}", code),
+        }
+    }
+
+    /// Get the 8 bit operand from the given `p` code for an indirection.
+    fn from_indirect(code: u8) -> Self {
+        match code {
+            0 => Self::AddrBC,
+            1 => Self::AddrDE,
+            2 => Self::AddrHLInc,
+            3 => Self::AddrHLDec,
+            _ => panic!("Unrecognized indirection code {}", code),
+        }
+    }
+}
+
+impl fmt::Display for Operand8 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::A => f.write_str("A"),
+            Self::B => f.write_str("B"),
+            Self::C => f.write_str("C"),
+            Self::D => f.write_str("D"),
+            Self::E => f.write_str("E"),
+            Self::H => f.write_str("H"),
+            Self::L => f.write_str("L"),
+            Self::AddrHL => f.write_str("(HL)"),
+            Self::AddrBC => f.write_str("(BC)"),
+            Self::AddrDE => f.write_str("(DE)"),
+            Self::AddrHLInc => f.write_str("(HL+)"),
+            Self::AddrHLDec => f.write_str("(HL-)"),
+            Self::Immediate => f.write_str("u8"),
+            Self::AddrImmediate => f.write_str("(u16)"),
+        }
+    }
+}
+
+/// 16 bit operand.
+#[derive(Copy, Clone, Debug)]
+pub enum Operand16 {
+    /// Register pair BC.
+    BC,
+    /// Register pair DE.
+    DE,
+    /// Register pair HL.
+    HL,
+    /// Register pair of the accumulator + flags register.
+    AF,
+    /// Stack pointer.
+    Sp,
+    /// Load value from immediate (and advance program counter). Cannot be used to store. Will
+    /// panic if used as the destination operand.
+    Immediate,
+}
+
+impl Operand16 {
+    /// Get a 16 bit operand from a register pair code, using the table of register pairs that
+    /// includes the stack pointer. Panics if the code is greater than 3.
+    fn from_pair_code_sp(code: u8) -> Operand16 {
+        match code {
+            0 => Operand16::BC,
+            1 => Operand16::DE,
+            2 => Operand16::HL,
+            3 => Operand16::Sp,
+            _ => panic!("Unrecognized register pair code {}", code),
+        }
+    }
+
+    /// Get a 16 bit operand from a register pair code, using the table of register pairs that
+    /// includes the accumulator-flags pair. Panics if the code is greater than 3.
+    fn from_pair_code_af(code: u8) -> Operand16 {
+        match code {
+            0 => Operand16::BC,
+            1 => Operand16::DE,
+            2 => Operand16::HL,
+            3 => Operand16::AF,
+            _ => panic!("Unrecognized register pair code {}", code),
+        }
+    }
+}
+
+impl fmt::Display for Operand16 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Operand16::BC => f.write_str("BC"),
+            Operand16::DE => f.write_str("DE"),
+            Operand16::HL => f.write_str("HL"),
+            Operand16::AF => f.write_str("AF"),
+            Operand16::Sp => f.write_str("SP"),
+            Operand16::Immediate => f.write_str("u16"),
+        }
+    }
+}
+
+/// Conditional for conditional jump/conditional ret.
+#[derive(Copy, Clone, Debug)]
+pub enum ConditionCode {
+    Unconditional,
+    NonZero,
+    Zero,
+    NoCarry,
+    Carry,
+}
+
+impl ConditionCode {
+    /// Get the condition code for the given relative-jump condition code. Relative jump condition
+    /// codes are for x = 0, z = 0, y = 3..=7 (the value given should be y). Panics if the given
+    /// value is not in range 3..=7.
+    fn from_jrcode(code: u8) -> Self {
+        match code {
+            3 => Self::Unconditional,
+            4 => Self::NonZero,
+            5 => Self::Zero,
+            6 => Self::NoCarry,
+            7 => Self::Carry,
+            _ => panic!("Unrecognized Relative-Jump condtion code {}", code),
+        }
+    }
+}
+
+impl fmt::Display for ConditionCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::Unconditional => Ok(()),
+            Self::NonZero => f.write_str("NZ"),
+            Self::Zero => f.write_str("Z"),
+            Self::NoCarry => f.write_str("NC"),
+            Self::Carry => f.write_str("C"),
+        }
+    }
+}


### PR DESCRIPTION
Parse all 1-byte opcodes into an enum that categorizes them and describes their operands.

Parsed opcodes implement `Display` outputting the assembly-like description of the operation similar to how opcodes are listed in most opcode charts, which is useful for debugging what is going on at any point. Additionally, for execution purposes, working off of a decoded enum makes it easier to implement execution by clearly grouping related instructions, even in some cases where they are separated in the op table/decode matching.

Opcode table generated from the result of decoding every opcode using this parser: https://docs.google.com/spreadsheets/d/1xHCs_O9qqz0R3k044gCi2SIEnXO6ugm63kZLlabuHh4/edit