### PR TITLE
Add parsing for CB-prefixed opcodes

### DIFF
--- a/feo3boy/src/bin/cb-opcode-table.rs
+++ b/feo3boy/src/bin/cb-opcode-table.rs
@@ -1,0 +1,19 @@
+//! Prints out all CB-prefixed opcodes in a CSV table for comparison against published opcode
+//! tables.
+
+use feo3boy::gbz80core::opcode::CBOpcode;
+
+fn main() {
+    for l in 0u8..=0xF {
+        print!(",{:#04X}", l);
+    }
+    println!();
+    for h in (0u8..=0xFF).step_by(0x10) {
+        print!("{:#04X}", h);
+        for l in 0u8..=0xF {
+            let opcode = CBOpcode::decode(h + l);
+            print!(",\"{}\"", opcode);
+        }
+        println!();
+    }
+}


### PR DESCRIPTION
Adds the CB prefixed opcodes.

Generated decoded table: https://docs.google.com/spreadsheets/d/1xHCs_O9qqz0R3k044gCi2SIEnXO6ugm63kZLlabuHh4/edit#gid=1514298343