### PR TITLE
Restructure interrupts so they don't require memory reads

### DIFF
--- a/feo3boy/src/gb.rs
+++ b/feo3boy/src/gb.rs
@@ -1,0 +1,65 @@
+use crate::gbz80core::{self, CpuContext, Gbz80State};
+use crate::memdev::{BiosRom, Cartridge, GbMmu};
+
+/// Represents a "real" gameboy, by explicitly using the GbMmu for memory.
+pub struct Gb {
+    /// State of the CPU in the system.
+    cpustate: Gbz80State,
+    /// MMU for the system.
+    mmu: Box<GbMmu>,
+}
+
+impl Gb {
+    /// Create a `Gb` with the given bios and cartridge.
+    pub fn new(bios: BiosRom, cart: Cartridge) -> Self {
+        Gb {
+            cpustate: Gbz80State::new(),
+            mmu: Box::new(GbMmu::new(bios, cart)),
+        }
+    }
+
+    /// Tick forward by one instruction, executing background and graphics processing
+    /// operations as needed.
+    pub fn tick(&mut self) {
+        gbz80core::tick::<_, Self>(self);
+    }
+}
+
+impl CpuContext for Gb {
+    type Mem = GbMmu;
+    type Interrupts = GbMmu;
+
+    #[inline]
+    fn cpustate(&self) -> &Gbz80State {
+        &self.cpustate
+    }
+
+    #[inline]
+    fn cpustate_mut(&mut self) -> &mut Gbz80State {
+        &mut self.cpustate
+    }
+
+    #[inline]
+    fn mem(&self) -> &Self::Mem {
+        self.mmu.as_ref()
+    }
+
+    #[inline]
+    fn mem_mut(&mut self) -> &mut Self::Mem {
+        self.mmu.as_mut()
+    }
+
+    #[inline]
+    fn interrupts(&self) -> &Self::Interrupts {
+        self.mmu.as_ref()
+    }
+
+    #[inline]
+    fn interrupts_mut(&mut self) -> &mut Self::Interrupts {
+        self.mmu.as_mut()
+    }
+
+    fn yield1m(&mut self) {
+        // TODO: run background processing while yielded.
+    }
+}

--- a/feo3boy/src/gbz80core/opcode.rs
+++ b/feo3boy/src/gbz80core/opcode.rs
@@ -4,7 +4,7 @@ use log::{debug, trace, warn};
 
 use super::oputils::{add8_flags, offset_addr, rotate_left9, rotate_right9, sub8_flags};
 use super::{AluOp, AluUnaryOp, ConditionCode, CpuContext, Flags, Operand16, Operand8};
-use crate::interrupts::InterruptFlags;
+use crate::interrupts::Interrupts;
 use crate::memdev::MemDevice;
 
 // Opcode References:
@@ -458,8 +458,8 @@ fn halt(ctx: &mut impl CpuContext) {
         // No need to special-case interrupts here, since the next `tick` call will un-halt anyway.
         ctx.cpustate_mut().halted = true;
     } else {
-        let enabled_interrupts = InterruptFlags::get_interrupt_enable(ctx.mem());
-        let pending_interrupts = ctx.cpustate().interrupt_vector;
+        let enabled_interrupts = ctx.interrupts().enabled();
+        let pending_interrupts = ctx.interrupts().queued();
         if enabled_interrupts.intersects(pending_interrupts) {
             panic!("Halt-Bug encountered (see method description).");
         } else {

--- a/feo3boy/src/interrupts.rs
+++ b/feo3boy/src/interrupts.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use bitflags::bitflags;
 
 use crate::memdev::{Addr, MemDevice};
@@ -24,20 +26,6 @@ bitflags! {
     }
 }
 
-impl InterruptFlags {
-    /// Reads the byte at 0xffff and converts it to `InterruptFlags`. Normally 0xffff is the
-    /// location of the interrupt enable register.
-    pub fn get_interrupt_enable(mem: &impl MemDevice) -> Self {
-        Self::from_bits_truncate(mem.read(0xffff.into()))
-    }
-
-    /// Sets the byte at 0xffff to these `InterruptFlags`. Normally 0xffff is the location of the
-    /// interrupt enable register.
-    pub fn set_interrupt_enable(self, mem: &mut impl MemDevice) {
-        mem.write(0xffff.into(), self.bits);
-    }
-}
-
 /// The Interrupt Enable (IE) register. Implements MemDevice.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct InterruptEnable(pub InterruptFlags);
@@ -59,5 +47,71 @@ impl MemDevice for InterruptEnable {
             addr
         );
         self.0 = InterruptFlags::from_bits_truncate(value);
+    }
+}
+
+/// Trait for accessing the (usually memory-mapped) registers for InterruptFlags and
+/// InterruptEnable.
+pub trait Interrupts {
+    /// Get the pending interrupt flags from the context.
+    fn queued(&self) -> InterruptFlags;
+
+    /// Set the pending flags for the context.
+    fn set_queued(&mut self, flags: InterruptFlags);
+
+    /// Sends the specified interrupts by adding them to the active interrupt flags.
+    #[inline]
+    fn send(&mut self, flags: InterruptFlags) {
+        self.set_queued(self.queued() | flags);
+    }
+
+    /// Get the enabled interrupt flags.
+    fn enabled(&self) -> InterruptFlags;
+
+    /// Set the enabled interrupt flags for the context.
+    fn set_enabled(&mut self, flags: InterruptFlags);
+}
+
+/// Wraps a mem-device, providing access to memory-mapped interrupt registers by reading
+/// and writing memory. This type assumes the interrupt vector is memory mapped at 0xff0f,
+/// and the interrupt enable register is memory mapped at 0xffff.
+#[repr(transparent)]
+pub struct MemInterrupts<M>(M);
+
+impl<M: MemDevice> MemInterrupts<M> {
+    /// Convert a reference to a memory device into a mem-interrupts accessor.
+    #[inline]
+    pub fn wrap<'a>(device: &'a M) -> &'a MemInterrupts<M> {
+        // This is safe because MemInterrupts is repr(transparent) so the layout of
+        // MemInterupts<M> is the same as M and because the returned reference has the
+        // same lifetime as the passed reference, so memory safety rules for M are upheld.
+        unsafe { mem::transmute(device) }
+    }
+
+    /// Convert a mutable reference to a memory device into a mem-interrupts accessor.
+    #[inline]
+    pub fn wrap_mut<'a>(device: &'a mut M) -> &'a mut MemInterrupts<M> {
+        // This is safe because MemInterrupts is repr(transparent) so the layout of
+        // MemInterupts<M> is the same as M and because the returned reference has the
+        // same lifetime as the passed reference, so memory safety rules for M are upheld.
+        unsafe { mem::transmute(device) }
+    }
+}
+
+impl<M: MemDevice> Interrupts for MemInterrupts<M> {
+    fn queued(&self) -> InterruptFlags {
+        InterruptFlags::from_bits_truncate(self.0.read(0xff0f.into()))
+    }
+
+    fn set_queued(&mut self, flags: InterruptFlags) {
+        self.0.write(0xff0f.into(), flags.bits);
+    }
+
+    fn enabled(&self) -> InterruptFlags {
+        InterruptFlags::from_bits_truncate(self.0.read(0xffff.into()))
+    }
+
+    fn set_enabled(&mut self, flags: InterruptFlags) {
+        self.0.write(0xffff.into(), flags.bits);
     }
 }

--- a/feo3boy/src/lib.rs
+++ b/feo3boy/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod gb;
 pub mod gbz80core;
 pub mod interrupts;
 pub mod memdev;


### PR DESCRIPTION
Previously there was no way to access the memory mapped interrupt vectors through the `CpuContext` traits, meaning that operations that wanted to act on interrupts explicitly had to do this by assuming the memory location and doing a read, then converting to `InterruptFlags`. With this change, the interrupt vector and interrupt enable are accessed through the `Interrupts` trait via `CpuContext` which allows the rust side of the code to make fewer assumptions about where these will be located in memory (obviously GB assembly code will still all have been written based on the real locations).