### PR TITLE
Use write_all not write for printing serial out.

### DIFF
--- a/feo3boy-player/src/main.rs
+++ b/feo3boy-player/src/main.rs
@@ -137,7 +137,7 @@ fn main() {
                     let bytes = gb.serial.stream.receive_bytes();
                     if bytes.len() != 0 {
                         for byte in bytes {
-                            stdout.write(&[byte]).unwrap();
+                            stdout.write_all(&[byte]).unwrap();
                         }
                         stdout.flush().unwrap();
                     }


### PR DESCRIPTION
`write` could return `Ok(0)` which the current code interprets as successfully haven written the serial output character when that actually means that nothing was written. IDK if this can actually happen with stdout, but it's better to use `write_all` since that ensures either everything gets written or an error occurs.