### PR TITLE
Derive memdev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "derive-syn-parse"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79116f119dd1dba1abf1f3405f03b9b0e79a27a3883864bfebded8a3dc768cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +818,7 @@ dependencies = [
  "bitflags 2.0.2",
  "criterion",
  "env_logger",
+ "feo3boy-memdev-derive",
  "feo3boy-opcodes",
  "log",
  "once_cell",
@@ -814,9 +826,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "feo3boy-memdev-derive"
+version = "0.1.0"
+dependencies = [
+ "derive-syn-parse",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
+]
+
+[[package]]
 name = "feo3boy-microcode-generator"
 version = "0.1.0"
 dependencies = [
+ "derive-syn-parse",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "feo3boy",
   "feo3boy-player",
   "feo3boy-opcodes",
+  "feo3boy-memdev-derive",
   "feo3boy-microcode-generator",
   "web-debugger",
 ]

--- a/feo3boy-memdev-derive/Cargo.toml
+++ b/feo3boy-memdev-derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "feo3boy-microcode-generator"
+name = "feo3boy-memdev-derive"
 version = "0.1.0"
 edition = "2021"
 
@@ -10,5 +10,5 @@ proc-macro = true
 derive-syn-parse = "0.1"
 syn = { version = "2", features = ["full"] }
 proc-macro2 = "1"
-quote = "1"
 proc-macro-crate = "1"
+quote = "1"

--- a/feo3boy-memdev-derive/src/bitflags.rs
+++ b/feo3boy-memdev-derive/src/bitflags.rs
@@ -1,0 +1,47 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{DeriveInput, Result};
+
+use crate::device_type::BitFlags;
+use crate::get_crate;
+
+/// Build an implementation of MemDevice for a BitFlags type. Requires the bitflags type
+/// to be `Copy`.
+pub fn build_flags(item: &DeriveInput, flags: &BitFlags) -> Result<TokenStream> {
+    let feo3boy = get_crate("feo3boy");
+    let ty = &item.ident;
+    let readable = match &flags.readwrite.readable {
+        Some((_, readable)) => readable.value.to_token_stream(),
+        None => quote! { #ty::all() },
+    };
+    let writable = match &flags.readwrite.writable {
+        Some((_, writable)) => writable.value.to_token_stream(),
+        None => quote! { #ty::all() },
+    };
+
+    Ok(quote! {
+        impl #feo3boy::memdev::MemDevice for #ty {
+            fn read(&self, addr: #feo3boy::memdev::Addr) -> u8 {
+                const READABLE_BITS: #ty = #readable;
+
+                assert!(
+                    addr.index() == 0,
+                    concat!("Address {} out of range for ", stringify!(#ty)),
+                    addr
+                );
+                (*self & READABLE_BITS).bits() | !READABLE_BITS.bits()
+            }
+
+            fn write(&mut self, addr: #feo3boy::memdev::Addr, val: u8) {
+                const WRITABLE_BITS: #ty = #writable;
+
+                assert!(
+                    addr.index() == 0,
+                    concat!("Address {} out of range for ", stringify!(#ty)),
+                    addr
+                );
+                *self = (*self - WRITABLE_BITS) | (#ty::from_bits_truncate(val) & WRITABLE_BITS)
+            }
+        }
+    })
+}

--- a/feo3boy-memdev-derive/src/bytewrapper.rs
+++ b/feo3boy-memdev-derive/src/bytewrapper.rs
@@ -1,0 +1,100 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{Data, DeriveInput, Error, Result, Type};
+
+use crate::device_type::ByteWrapper;
+use crate::get_crate;
+
+/// Build the byte wrapper type for the derive input.
+pub fn build_byte_wrapper(item: &DeriveInput, wrapper: &ByteWrapper) -> Result<TokenStream> {
+    let field = match &item.data {
+        Data::Struct(s) => match &s.fields {
+            syn::Fields::Named(fields) => {
+                if fields.named.len() != 1 {
+                    return Err(Error::new(
+                        item.ident.span(),
+                        "#[memdev(byte, ...)] must be used on a struct with exactly 1 \
+                        field of type u8",
+                    ));
+                }
+                let field = &fields.named[0];
+                check_type_u8(&field.ty)?;
+                let name = field.ident.as_ref().unwrap();
+                quote! { #name }
+            }
+            syn::Fields::Unnamed(fields) => {
+                if fields.unnamed.len() != 1 {
+                    return Err(Error::new(
+                        item.ident.span(),
+                        "#[memdev(byte, ...)] must be used on a struct with exactly 1 \
+                        field of type u8",
+                    ));
+                }
+                let field = &fields.unnamed[0];
+                check_type_u8(&field.ty)?;
+                quote! { 0 }
+            }
+            syn::Fields::Unit => {
+                return Err(Error::new(
+                    item.ident.span(),
+                    "#[memdev(byte, ...)] does not work on unit structs. Must be a struct \
+                    with exactly 1 field of type u8",
+                ))
+            }
+        },
+        _ => {
+            return Err(Error::new(
+                item.ident.span(),
+                "#[memdev(byte, ...)] only works on structs",
+            ))
+        }
+    };
+
+    let feo3boy = get_crate("feo3boy");
+    let ty = &item.ident;
+    let readable = match &wrapper.readwrite.readable {
+        Some((_, readable)) => readable.value.to_token_stream(),
+        None => quote! { 0xffu8 },
+    };
+    let writable = match &wrapper.readwrite.writable {
+        Some((_, writable)) => writable.value.to_token_stream(),
+        None => quote! { 0xffu8 },
+    };
+
+    Ok(quote! {
+        impl #feo3boy::memdev::MemDevice for #ty {
+            fn read(&self, addr: #feo3boy::memdev::Addr) -> u8 {
+                const READABLE_BITS: u8 = #readable;
+
+                assert!(
+                    addr.index() == 0,
+                    concat!("Address {} out of range for ", stringify!(#ty)),
+                    addr
+                );
+                self.#field & READABLE_BITS | !READABLE_BITS
+            }
+
+            fn write(&mut self, addr: #feo3boy::memdev::Addr, val: u8) {
+                const WRITABLE_BITS: u8 = #writable;
+
+                assert!(
+                    addr.index() == 0,
+                    concat!("Address {} out of range for ", stringify!(#ty)),
+                    addr
+                );
+                self.#field = (self.#field & !WRITABLE_BITS) | (val & WRITABLE_BITS)
+            }
+        }
+    })
+}
+
+/// Verify that the given ty is a path type with ident `u8`.
+fn check_type_u8(ty: &Type) -> Result<()> {
+    match ty {
+        Type::Path(p) if p.qself.is_none() && p.path.is_ident("u8") => Ok(()),
+        _ => Err(Error::new_spanned(
+            ty,
+            "Type of the field of a #[memdev(byte, ...)] must be u8.",
+        )),
+    }
+}

--- a/feo3boy-memdev-derive/src/device_type.rs
+++ b/feo3boy-memdev-derive/src/device_type.rs
@@ -1,0 +1,134 @@
+//! Provides types (with parsing support) for representing the attributes used in the
+//! #[memdev(...)] arguments.
+
+use derive_syn_parse::Parse;
+use syn::parse::{Parse, ParseStream};
+use syn::{DeriveInput, Error, Expr, Meta, Result, Token};
+
+/// Which type of device are we deriving a value for?
+#[derive(Parse)]
+pub enum DeviceType {
+    /// The type is a wrapper around a single byte.
+    #[peek(kw::byte, name = "ByteWrapper")]
+    ByteWrapper(ByteWrapper),
+    /// The type is a wrapper around bitflags.
+    #[peek(kw::bitflags, name = "BitFlags")]
+    BitFlags(BitFlags),
+    /// Passthrough mem device.
+    #[peek(kw::passthrough, name = "PassThrough")]
+    Passthrough(kw::passthrough),
+}
+
+impl DeviceType {
+    /// Finds an attribute indicating which DeviceType this is.
+    pub fn extract_from(input: &DeriveInput) -> Result<DeviceType> {
+        let matches = input
+            .attrs
+            .iter()
+            .filter_map(|attr| match &attr.meta {
+                Meta::Path(path) => {
+                    if path.is_ident("memdev") {
+                        Some(Err(Error::new_spanned(
+                            path,
+                            "#[memdev] on the type definition requires an argument",
+                        )))
+                    } else {
+                        None
+                    }
+                }
+                Meta::List(list) => {
+                    if list.path.is_ident("memdev") {
+                        Some(syn::parse2::<DeviceType>(list.tokens.clone()))
+                    } else {
+                        None
+                    }
+                }
+                Meta::NameValue(nv) => {
+                    if nv.path.is_ident("memdev") {
+                        Some(Err(Error::new_spanned(
+                            &nv.path,
+                            "`#[memdev]` attribute on a type uses list syntax",
+                        )))
+                    } else {
+                        None
+                    }
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+        if matches.len() == 1 {
+            Ok(matches.into_iter().next().unwrap())
+        } else {
+            Err(Error::new(
+                input.ident.span(),
+                format!(
+                    "Expected exactly 1 #[memdev] attribute, got {}",
+                    matches.len()
+                ),
+            ))
+        }
+    }
+}
+
+/// Contents of the `#[memdev(byte, readable = ..., writable = ...)]` expression.
+#[derive(Parse)]
+pub struct ByteWrapper {
+    /// The byte token that starts this expression.
+    pub byte: kw::byte,
+    /// The values for the `readable = ...`  and `writable = ...` inputs.
+    pub readwrite: ReadableWritable,
+}
+
+/// Contents of the `#[memdev(bitflags, readable = ..., writable = ...)]` expression.
+#[derive(Parse)]
+pub struct BitFlags {
+    /// The bitflags token that starts this expression.
+    pub byte: kw::bitflags,
+    /// The values for the `readable = ...`  and `writable = ...` inputs.
+    pub readwrite: ReadableWritable,
+}
+
+pub struct ReadableWritable {
+    /// The value set for "readable" if any.
+    pub readable: Option<(Token![,], Readable)>,
+    /// The value set for "writable" if any.
+    pub writable: Option<(Token![,], Writable)>,
+}
+
+impl Parse for ReadableWritable {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut readable = None;
+        let mut writable = None;
+        if input.peek(Token![,]) && input.peek2(kw::readable) {
+            readable = Some((input.parse()?, input.parse()?));
+        }
+        if input.peek(Token![,]) && input.peek2(kw::writable) {
+            writable = Some((input.parse()?, input.parse()?));
+        }
+        Ok(Self { readable, writable })
+    }
+}
+
+/// The sequence `readable = <expr>`.
+#[derive(Parse)]
+pub struct Readable {
+    pub readable: kw::readable,
+    pub equals: Token![=],
+    pub value: Expr,
+}
+
+/// The sequence `readable = <expr>`.
+#[derive(Parse)]
+pub struct Writable {
+    pub readable: kw::writable,
+    pub equals: Token![=],
+    pub value: Expr,
+}
+
+mod kw {
+    syn::custom_keyword!(byte);
+    syn::custom_keyword!(bitflags);
+    syn::custom_keyword!(passthrough);
+
+    syn::custom_keyword!(readable);
+    syn::custom_keyword!(writable);
+}

--- a/feo3boy-memdev-derive/src/lib.rs
+++ b/feo3boy-memdev-derive/src/lib.rs
@@ -1,0 +1,48 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro_crate::FoundCrate;
+use quote::quote;
+use syn::{DeriveInput, Result};
+
+use crate::device_type::DeviceType;
+
+mod bitflags;
+mod bytewrapper;
+mod device_type;
+mod passthrough;
+
+/// Generates an implementation of `MemDevice` for a type.
+#[proc_macro_derive(MemDevice, attributes(memdev))]
+pub fn derive_mem_device(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(item as DeriveInput);
+
+    match build_memdev_derives(&input) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.into_compile_error().into(),
+    }
+}
+
+/// Get a representation of either `crate` or `::<name>` to use for the specified crate.
+fn get_crate(name: &str) -> TokenStream {
+    match proc_macro_crate::crate_name(name) {
+        Ok(FoundCrate::Itself) => quote! { crate },
+        Ok(FoundCrate::Name(name)) => {
+            let name = Ident::new(&name, Span::call_site());
+            quote! { ::#name }
+        }
+        Err(e) => panic!(
+            "Unable to find the {} crate: {}, required by this macro.",
+            name, e
+        ),
+    }
+}
+
+/// Generate memdev derives for this type.
+fn build_memdev_derives(item: &DeriveInput) -> Result<TokenStream> {
+    let device_type = DeviceType::extract_from(item)?;
+
+    match device_type {
+        DeviceType::ByteWrapper(ref wrapper) => bytewrapper::build_byte_wrapper(item, wrapper),
+        DeviceType::BitFlags(ref flags) => bitflags::build_flags(item, flags),
+        DeviceType::Passthrough(_) => passthrough::build_passthrough(item),
+    }
+}

--- a/feo3boy-memdev-derive/src/passthrough.rs
+++ b/feo3boy-memdev-derive/src/passthrough.rs
@@ -1,0 +1,62 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{Data, DeriveInput, Error, Result};
+
+use crate::get_crate;
+
+/// Build the byte wrapper type for the derive input.
+pub fn build_passthrough(item: &DeriveInput) -> Result<TokenStream> {
+    let field = match &item.data {
+        Data::Struct(s) => match &s.fields {
+            syn::Fields::Named(fields) => {
+                if fields.named.len() != 1 {
+                    return Err(Error::new(
+                        item.ident.span(),
+                        "#[memdev(passthrough)] must be used on a struct with exactly 1 \
+                        field.",
+                    ));
+                }
+                let field = &fields.named[0];
+                field.ident.to_token_stream()
+            }
+            syn::Fields::Unnamed(fields) => {
+                if fields.unnamed.len() != 1 {
+                    return Err(Error::new(
+                        item.ident.span(),
+                        "#[memdev(passthrough)] must be used on a struct with exactly 1 \
+                        field.",
+                    ));
+                }
+                quote! { 0 }
+            }
+            syn::Fields::Unit => {
+                return Err(Error::new(
+                    item.ident.span(),
+                    "#[memdev(passthrough)] does not work on unit structs. Must be a struct \
+                    with exactly 1 field",
+                ))
+            }
+        },
+        _ => {
+            return Err(Error::new(
+                item.ident.span(),
+                "#[memdev(passthrough)] only works on structs",
+            ))
+        }
+    };
+
+    let feo3boy = get_crate("feo3boy");
+    let ty = &item.ident;
+
+    Ok(quote! {
+        impl #feo3boy::memdev::MemDevice for #ty {
+            fn read(&self, addr: #feo3boy::memdev::Addr) -> u8 {
+                #feo3boy::memdev::MemDevice::read(&self.#field, addr)
+            }
+
+            fn write(&mut self, addr: #feo3boy::memdev::Addr, val: u8) {
+                #feo3boy::memdev::MemDevice::write(&mut self.#field, addr, val)
+            }
+        }
+    })
+}

--- a/feo3boy-microcode-generator/src/generator.rs
+++ b/feo3boy-microcode-generator/src/generator.rs
@@ -232,6 +232,8 @@ fn generate_descriptor_def(
 ) -> TokenStream {
     let doc = format!("Provides descriptive informaton about an instruction from the microcode.");
 
+    let feo3boy_opcodes = crate::get_crate("feo3boy-opcodes");
+
     quote! {
         #[doc = #doc]
         #[derive(Debug, Clone)]
@@ -240,12 +242,12 @@ fn generate_descriptor_def(
             pub name: String,
             /// Arguments to this operator. Stack arguments are in the order they should
             /// be popped off the stack. Field arguments are provided as literals.
-            pub args: Vec<Arg<#allowed_types_name>>,
+            pub args: Vec<#feo3boy_opcodes::compiler::args::Arg<#allowed_types_name>>,
             /// Values returned from this operator. All of them go on the stack. Provided
             /// in the order they should be pushed onto the stack.
             pub returns: Vec<#allowed_types_name>,
             /// Which type of operation this is (an extern or a pure function).
-            pub optype: OperationType<#externs_name>,
+            pub optype: #feo3boy_opcodes::compiler::OperationType<#externs_name>,
         }
     }
 }

--- a/feo3boy-microcode-generator/src/parsing.rs
+++ b/feo3boy-microcode-generator/src/parsing.rs
@@ -1,10 +1,12 @@
+use derive_syn_parse::Parse;
 use proc_macro2::Ident;
-use syn::parse::{Error, Parse, ParseStream, Result};
+use syn::parse::{Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::token::Bracket;
 use syn::{bracketed, Attribute, Token};
 
 /// The contents of the `allowed_types!` macro invocation.
+#[derive(Parse)]
 pub struct AllowedTypesMappings {
     pub name: AllowedTypesName,
     /// The comma token between the name and the types list.
@@ -15,35 +17,15 @@ pub struct AllowedTypesMappings {
     pub trailing_comma: Option<Token![,]>,
 }
 
-impl Parse for AllowedTypesMappings {
-    fn parse(input: ParseStream) -> Result<Self> {
-        Ok(AllowedTypesMappings {
-            name: input.parse()?,
-            comma: input.parse()?,
-            types: input.parse()?,
-            trailing_comma: input.parse()?,
-        })
-    }
-}
-
 /// Defines the mapping of the allowed-types name.
+#[derive(Parse)]
 pub struct AllowedTypesName {
     /// The literal token `name`.
-    pub name: Name,
+    pub name: kw::name,
     /// The assignment on the first line of the macro invocation.
     pub equals: Token![=],
     /// The identifier for the AllowedTypes generated type.
     pub ident: Ident,
-}
-
-impl Parse for AllowedTypesName {
-    fn parse(input: ParseStream) -> Result<Self> {
-        Ok(Self {
-            name: input.parse()?,
-            equals: input.parse()?,
-            ident: input.parse()?,
-        })
-    }
 }
 
 /// List of allowed types. Of the form:
@@ -56,7 +38,7 @@ impl Parse for AllowedTypesName {
 /// ```
 pub struct AllowedTypesList {
     /// The "types" token.
-    pub types: Types,
+    pub types: kw::types,
     /// The assignment between `types` and `[`
     pub equals: Token![=],
     /// The brackets for the type mappings.
@@ -100,34 +82,7 @@ impl Parse for AllowedTypesMapping {
     }
 }
 
-/// The literal ident "types"
-pub struct Types {
-    pub ident: Ident,
-}
-
-impl Parse for Types {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let ident: Ident = input.parse()?;
-        if ident != "types" {
-            Err(Error::new(ident.span(), "Expected \"types\""))
-        } else {
-            Ok(Self { ident })
-        }
-    }
-}
-
-/// The literal ident "name"
-pub struct Name {
-    pub ident: Ident,
-}
-
-impl Parse for Name {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let ident: Ident = input.parse()?;
-        if ident != "name" {
-            Err(Error::new(ident.span(), "Expected \"name\""))
-        } else {
-            Ok(Self { ident })
-        }
-    }
+mod kw {
+    syn::custom_keyword!(types);
+    syn::custom_keyword!(name);
 }

--- a/feo3boy/Cargo.toml
+++ b/feo3boy/Cargo.toml
@@ -9,6 +9,7 @@ test-roms = []
 
 [dependencies]
 feo3boy-opcodes = { path = "../feo3boy-opcodes" }
+feo3boy-memdev-derive = { path = "../feo3boy-memdev-derive" }
 bitflags = "2"
 log = "0.4"
 once_cell = "1"

--- a/feo3boy/src/gb.rs
+++ b/feo3boy/src/gb.rs
@@ -1,14 +1,14 @@
-use crate::apu::{self, ApuContext, ApuState};
+use crate::apu::{self, ApuContext, ApuRegs, ApuState};
 use crate::gbz80core::direct_executor::DirectExecutor;
 use crate::gbz80core::executor::Executor;
 use crate::gbz80core::microcode_executor::MicrocodeExecutor;
 use crate::gbz80core::{CpuContext, ExecutorContext, Gbz80State};
-use crate::input::{self, ButtonStates, InputContext};
+use crate::input::{self, ButtonRegister, ButtonStates, InputContext};
 use crate::interrupts::InterruptContext;
-use crate::memdev::{BiosRom, Cartridge, GbMmu, IoRegsContext, MemContext, Oam, Vram};
-use crate::ppu::{self, PpuContext, PpuState};
-use crate::serial::{self, SerialContext, SerialState};
-use crate::timer::{self, TimerContext, TimerState};
+use crate::memdev::{BiosRom, Cartridge, GbMmu, MemContext, Oam, Vram};
+use crate::ppu::{self, PpuContext, PpuRegs, PpuState};
+use crate::serial::{self, SerialContext, SerialRegs, SerialState};
+use crate::timer::{self, TimerContext, TimerRegs, TimerState};
 
 /// Represents a "real" gameboy, by explicitly using the GbMmu for memory.
 #[derive(Clone, Debug)]
@@ -151,20 +151,6 @@ impl<E: Executor> InterruptContext for Gb<E> {
     }
 }
 
-impl<E: Executor> IoRegsContext for Gb<E> {
-    type IoRegs = <GbMmu as IoRegsContext>::IoRegs;
-
-    #[inline]
-    fn ioregs(&self) -> &Self::IoRegs {
-        self.mmu.ioregs()
-    }
-
-    #[inline]
-    fn ioregs_mut(&mut self) -> &mut Self::IoRegs {
-        self.mmu.ioregs_mut()
-    }
-}
-
 impl<E: Executor> InputContext for Gb<E> {
     #[inline]
     fn button_states(&self) -> ButtonStates {
@@ -173,6 +159,14 @@ impl<E: Executor> InputContext for Gb<E> {
 
     fn set_button_states(&mut self, button_states: ButtonStates) {
         self.button_states = button_states;
+    }
+
+    fn button_reg(&self) -> ButtonRegister {
+        self.mmu.io.buttons
+    }
+
+    fn set_button_reg(&mut self, buttons: ButtonRegister) {
+        self.mmu.io.buttons = buttons;
     }
 }
 
@@ -185,6 +179,14 @@ impl<E: Executor> SerialContext for Gb<E> {
     fn serial_mut(&mut self) -> &mut SerialState {
         &mut self.serial
     }
+
+    fn serial_regs(&self) -> &SerialRegs {
+        &self.mmu.io.serial_regs
+    }
+
+    fn serial_regs_mut(&mut self) -> &mut SerialRegs {
+        &mut self.mmu.io.serial_regs
+    }
 }
 
 impl<E: Executor> TimerContext for Gb<E> {
@@ -195,6 +197,14 @@ impl<E: Executor> TimerContext for Gb<E> {
 
     fn timer_mut(&mut self) -> &mut TimerState {
         &mut self.timer
+    }
+
+    fn timer_regs(&self) -> &TimerRegs {
+        &self.mmu.io.timer_regs
+    }
+
+    fn timer_regs_mut(&mut self) -> &mut TimerRegs {
+        &mut self.mmu.io.timer_regs
     }
 }
 
@@ -207,6 +217,14 @@ impl<E: Executor> ApuContext for Gb<E> {
     fn apu_mut(&mut self) -> &mut ApuState {
         &mut self.apu
     }
+
+    fn apu_regs(&self) -> &ApuRegs {
+        &self.mmu.io.apu_regs
+    }
+
+    fn apu_regs_mut(&mut self) -> &mut ApuRegs {
+        &mut self.mmu.io.apu_regs
+    }
 }
 
 impl<E: Executor> PpuContext for Gb<E> {
@@ -217,6 +235,14 @@ impl<E: Executor> PpuContext for Gb<E> {
 
     fn ppu_mut(&mut self) -> &mut PpuState {
         &mut self.ppu
+    }
+
+    fn ppu_regs(&self) -> &PpuRegs {
+        &self.mmu.io.ppu_regs
+    }
+
+    fn ppu_regs_mut(&mut self) -> &mut PpuRegs {
+        &mut self.mmu.io.ppu_regs
     }
 
     fn vram(&self) -> &Vram {

--- a/feo3boy/src/lib.rs
+++ b/feo3boy/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+mod macros;
+
 pub mod apu;
 pub mod bits;
 pub mod gb;

--- a/feo3boy/src/macros.rs
+++ b/feo3boy/src/macros.rs
@@ -1,0 +1,55 @@
+//! Exported macro definitions. This is a separate module because macros must be defined
+//! before the module they are used in (one of the few cases of declaration
+//! order-dependence in Rust).
+
+#[macro_export]
+macro_rules! memdev_fields {
+    ($ty:ident {
+        $($start:literal $(..= $end:literal)? => $target:tt,)*
+    }) => {
+        impl $crate::memdev::MemDevice for $ty {
+            fn read(&self, addr: $crate::memdev::Addr) -> u8 {
+                match addr.relative() {
+                    $($start $(..= $end)? => memdev_fields!(@reader: self, addr.offset_by($start), $target),)*
+                    _ => panic!(concat!("Address {} out of range for ", stringify!($ty)), addr),
+                }
+            }
+
+            fn write(&mut self, addr: $crate::memdev::Addr, val: u8) {
+                match addr.relative() {
+                    $($start $(..= $end)? => memdev_fields!(@writer: self, addr.offset_by($start), val, $target),)*
+                    _ => panic!(concat!("Address {} out of range for ", stringify!($ty)), addr),
+                }
+            }
+        }
+    };
+
+    (@reader: $self:ident, $addr:expr, $target:ident) => {
+        $crate::memdev::MemDevice::read(&$self.$target, $addr)
+    };
+    (@reader: $self:ident, $addr:expr, $target:literal) => {
+        $target
+    };
+    (@reader: $self:ident, $addr:expr, { $target:ident, skip_over: $skip:literal }) => {
+        $crate::memdev::MemDevice::read(&$self.$target, $addr.skip_over($skip))
+    };
+    (@reader: $self:ident, $addr:expr, { $target:ident, readonly }) => {
+        memdev_fields!(@reader: $self, $addr, $target)
+    };
+
+    (@writer: $self:ident, $addr:expr, $val:ident, $target:ident) => {
+        $crate::memdev::MemDevice::write(&mut $self.$target, $addr, $val)
+    };
+    (@writer: $self:ident, $addr:expr, $val:ident, $target:literal) => {
+        ()
+    };
+    (@writer: $self:ident, $addr:expr, $val:ident, { $target:ident, skip_over: $skip:literal }) => {
+        $crate::memdev::MemDevice::write(&mut $self.$target, $addr.skip_over($skip), $val)
+    };
+    (@writer: $self:ident, $addr:expr, $val:ident, { $target:ident, readonly }) => {
+        ()
+    };
+
+    (@addr: $base:ident, $addr:tt) => { $base.offset_by($addr) };
+    (@addr: $base:ident, $addr:literal..=$end:literal) => { $base.offset_by($addr) };
+}

--- a/feo3boy/src/memdev/cartridge.rs
+++ b/feo3boy/src/memdev/cartridge.rs
@@ -211,6 +211,10 @@ impl Cartridge {
                         0
                     }
                     (2 | 3, Err(e)) => return Err(e),
+                    (2 | 3, Ok(0)) => {
+                        warn!("MBC1 + RAM cartridge had 0 ram banks");
+                        0
+                    }
                     (2 | 3, Ok(size @ (1 | 4))) => size,
                     (2 | 3, Ok(ram_size)) => {
                         return Err(ParseCartridgeError::UnsupportedRamSize { rom_type, ram_size })

--- a/web-debugger/src/memview/mod.rs
+++ b/web-debugger/src/memview/mod.rs
@@ -91,7 +91,7 @@ impl Component for Memview {
 
 impl Memview {
     fn view_bios(&self, ctx: &Context<Self>) -> Html {
-        let enabled = ctx.props().mem.io.bios_enabled;
+        let enabled = ctx.props().mem.io.bios_enable.enabled();
         let enabled_class = match enabled {
             false => "disabled",
             true => "enabled",
@@ -202,14 +202,14 @@ pub fn view_io(props: &ViewIoProps) -> Html {
         <div class="line">
             {addr(0xff01)}
             {named("Serial Data")}
-            <span class="byte">{hexbyte(props.io.serial_data)}</span>
-            <span class="byte charinterp">{interpret_as_char(props.io.serial_data)}</span>
-            <span class="byte">{format!("{:08b}", props.io.serial_data)}</span>
+            <span class="byte">{hexbyte(props.io.serial_regs.serial_data)}</span>
+            <span class="byte charinterp">{interpret_as_char(props.io.serial_regs.serial_data)}</span>
+            <span class="byte">{format!("{:08b}", props.io.serial_regs.serial_data)}</span>
         </div>
         <div class="line">
             {addr(0xff02)}
             {named("Serial Control")}
-            <span class="byte">{hexbyte(props.io.serial_control)}</span>
+            <span class="byte">{hexbyte(props.io.serial_regs.serial_control)}</span>
         </div>
         <div class="line bad">
             {addr(0xff03)}
@@ -218,22 +218,22 @@ pub fn view_io(props: &ViewIoProps) -> Html {
         <div class="line">
             {addr(0xff04)}
             {named("Divider")}
-            <span class="byte">{hex16(props.io.divider)}</span>
+            <span class="byte">{hex16(props.io.timer_regs.divider)}</span>
         </div>
         <div class="line">
             {addr(0xff05)}
             {named("Timer Accumulator")}
-            <span class="byte">{hexbyte(props.io.timer)}</span>
+            <span class="byte">{hexbyte(props.io.timer_regs.timer)}</span>
         </div>
         <div class="line">
             {addr(0xff06)}
             {named("Timer Modulo")}
-            <span class="byte">{hexbyte(props.io.timer_mod)}</span>
+            <span class="byte">{hexbyte(props.io.timer_regs.timer_mod)}</span>
         </div>
         <div class="line">
             {addr(0xff07)}
             {named("Timer Control")}
-            <span class="byte">{hexbyte(props.io.timer_control.bits())}</span>
+            <span class="byte">{hexbyte(props.io.timer_regs.timer_control.bits())}</span>
         </div>
         <div class="line bad">
             {addr_range(0xff08..=0xff0e)}
@@ -261,62 +261,62 @@ pub fn view_io(props: &ViewIoProps) -> Html {
         <div class="line">
             {addr(0xff40)}
             {named("LCD Control")}
-            <span class="byte">{hexbyte(props.io.lcd_control.bits())}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.lcd_control.bits())}</span>
         </div>
         <div class="line">
             {addr(0xff41)}
             {named("LCD Status")}
-            <span class="byte">{hexbyte(props.io.lcd_status.bits())}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.lcd_status.bits())}</span>
         </div>
         <div class="line">
             {addr(0xff42)}
             {named("SCX")}
-            <span class="byte">{hexbyte(props.io.scroll_x)}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.scroll_x)}</span>
         </div>
         <div class="line">
             {addr(0xff43)}
             {named("SCY")}
-            <span class="byte">{hexbyte(props.io.scroll_y)}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.scroll_y)}</span>
         </div>
         <div class="line">
             {addr(0xff44)}
             {named("LY")}
-            <span class="byte">{hexbyte(props.io.lcdc_y)}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.lcdc_y)}</span>
         </div>
         <div class="line">
             {addr(0xff45)}
             {named("LYC")}
-            <span class="byte">{hexbyte(props.io.lcdc_y_compare)}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.lcdc_y_compare)}</span>
         </div>
         <div class="line unimplemented">
             {addr(0xff46)}
             {named("DMA")}
-            <span class="byte">{hexbyte(props.io.dma_addr)}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.dma_addr)}</span>
         </div>
         <div class="line">
             {addr(0xff47)}
             {named("BGP")}
-            <span class="byte">{hexbyte(props.io.bg_palette)}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.bg_palette)}</span>
         </div>
         <div class="line">
             {addr(0xff48)}
             {named("OBP0")}
-            <span class="byte">{hexbyte(props.io.obj_palette[0])}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.obj_palette[0])}</span>
         </div>
         <div class="line">
             {addr(0xff49)}
             {named("OBP1")}
-            <span class="byte">{hexbyte(props.io.obj_palette[1])}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.obj_palette[1])}</span>
         </div>
         <div class="line">
             {addr(0xff4a)}
             {named("WY")}
-            <span class="byte">{hexbyte(props.io.window_y)}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.window_y)}</span>
         </div>
         <div class="line">
             {addr(0xff4b)}
             {named("WX")}
-            <span class="byte">{hexbyte(props.io.window_x)}</span>
+            <span class="byte">{hexbyte(props.io.ppu_regs.window_x)}</span>
         </div>
         <div class="line bad">
             {addr_range(0xff4c..=0xff4f)}
@@ -325,7 +325,7 @@ pub fn view_io(props: &ViewIoProps) -> Html {
         <div class="line write-only">
             {addr(0xff50)}
             {named("BIOS Enabled")}
-            <span>{props.io.bios_enabled}</span>
+            <span>{props.io.bios_enable.enabled()}</span>
         </div>
         <div class="line bad">
             {addr_range(0xff51..=0xff7f)}


### PR DESCRIPTION
Change IoRegs to use MemDevices. This is based on the Deps update change, so that should be merged first.

Take the useage-specific registers like Serial Regs, Timer Regs, Apu
Regs, and Ppu Regs and move them to separate types defined alongside the
thing that they are the registers for, and replace the many-fields in
MemMappedIo with single fields of the corresponding mapped Regs type.

Delete the IoRegs type entirely and replace it with having each custom
context have accessors for the usage-specific regs, e.g. PpuContext
supplies ppu_regs() and ppu_regs_mut() for accessing those subsets of
the registers.

Add macros (both procedural derive macros and a macro_rules macro) for
deriving certain common types of MemDevice and change many of the fields
of these register types to one-byte MemDevices which are just mapped to
the correct address.