### PR TITLE
Allow read/write of blocks of [u8] in memory.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,8 @@ dependencies = [
  "feo3boy-opcodes",
  "log",
  "once_cell",
+ "rand",
+ "rand_pcg",
  "thiserror",
 ]
 
@@ -2001,6 +2003,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2091,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]

--- a/feo3boy-memdev-derive/src/bitswrapper.rs
+++ b/feo3boy-memdev-derive/src/bitswrapper.rs
@@ -1,0 +1,117 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{Data, DeriveInput, Error, Result, Type};
+
+use crate::device_type::BitsWrapper;
+use crate::get_crate;
+
+/// Build the byte wrapper type for the derive input.
+pub fn build_bits_wrapper(item: &DeriveInput, wrapper: &BitsWrapper) -> Result<TokenStream> {
+    let field = match &item.data {
+        Data::Struct(s) => match &s.fields {
+            syn::Fields::Named(fields) => {
+                if fields.named.len() != 1 {
+                    return Err(Error::new(
+                        item.ident.span(),
+                        "#[memdev(bits, ...)] must be used on a struct with exactly 1 \
+                        field of type u8",
+                    ));
+                }
+                let field = &fields.named[0];
+                check_type_u8(&field.ty)?;
+                let name = field.ident.as_ref().unwrap();
+                quote! { #name }
+            }
+            syn::Fields::Unnamed(fields) => {
+                if fields.unnamed.len() != 1 {
+                    return Err(Error::new(
+                        item.ident.span(),
+                        "#[memdev(bits, ...)] must be used on a struct with exactly 1 \
+                        field of type u8",
+                    ));
+                }
+                let field = &fields.unnamed[0];
+                check_type_u8(&field.ty)?;
+                quote! { 0 }
+            }
+            syn::Fields::Unit => {
+                return Err(Error::new(
+                    item.ident.span(),
+                    "#[memdev(bits, ...)] does not work on unit structs. Must be a struct \
+                    with exactly 1 field of type u8",
+                ))
+            }
+        },
+        _ => {
+            return Err(Error::new(
+                item.ident.span(),
+                "#[memdev(bits, ...)] only works on structs",
+            ))
+        }
+    };
+
+    let feo3boy = get_crate("feo3boy");
+    let ty = &item.ident;
+    let readable = match &wrapper.readwrite.readable {
+        Some((_, readable)) => readable.value.to_token_stream(),
+        None => quote! { 0xffu8 },
+    };
+    let writable = match &wrapper.readwrite.writable {
+        Some((_, writable)) => writable.value.to_token_stream(),
+        None => quote! { 0xffu8 },
+    };
+
+    let read = quote! {
+        self.#field & READABLE_BITS | !READABLE_BITS
+    };
+    let write = quote! {
+        self.#field = (self.#field & !WRITABLE_BITS) | (val & WRITABLE_BITS)
+    };
+
+    Ok(quote! {
+        impl #feo3boy::memdev::MemDevice for #ty {
+            const LEN: usize = 1;
+
+            fn read_byte_relative(&self, addr: #feo3boy::memdev::RelativeAddr) -> u8 {
+                const READABLE_BITS: u8 = #readable;
+                #feo3boy::check_addr!(#ty, addr);
+                #read
+            }
+
+            fn write_byte_relative(&mut self, addr: #feo3boy::memdev::RelativeAddr, val: u8) {
+                const WRITABLE_BITS: u8 = #writable;
+                #feo3boy::check_addr!(#ty, addr);
+                #write;
+            }
+
+            fn read_bytes_relative(&self, addr: #feo3boy::memdev::RelativeAddr, data: &mut [u8]) {
+                const READABLE_BITS: u8 = #readable;
+                #feo3boy::check_addr!(#ty, addr, data.len());
+                match data.first_mut() {
+                    Some(data) => *data = #read,
+                    None => {}
+                }
+            }
+
+            fn write_bytes_relative(&mut self, addr: #feo3boy::memdev::RelativeAddr, data: &[u8]) {
+                const WRITABLE_BITS: u8 = #writable;
+                #feo3boy::check_addr!(#ty, addr, data.len());
+                match data.first().copied() {
+                    Some(val) => #write,
+                    None => {}
+                }
+            }
+        }
+    })
+}
+
+/// Verify that the given ty is a path type with ident `u8`.
+fn check_type_u8(ty: &Type) -> Result<()> {
+    match ty {
+        Type::Path(p) if p.qself.is_none() && p.path.is_ident("u8") => Ok(()),
+        _ => Err(Error::new_spanned(
+            ty,
+            "Type of the field of a #[memdev(bits, ...)] must be u8.",
+        )),
+    }
+}

--- a/feo3boy-memdev-derive/src/bytewrapper.rs
+++ b/feo3boy-memdev-derive/src/bytewrapper.rs
@@ -1,100 +1,46 @@
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
-use syn::{Data, DeriveInput, Error, Result, Type};
+use quote::quote;
+use syn::{DeriveInput, Result};
 
 use crate::device_type::ByteWrapper;
 use crate::get_crate;
 
 /// Build the byte wrapper type for the derive input.
 pub fn build_byte_wrapper(item: &DeriveInput, wrapper: &ByteWrapper) -> Result<TokenStream> {
-    let field = match &item.data {
-        Data::Struct(s) => match &s.fields {
-            syn::Fields::Named(fields) => {
-                if fields.named.len() != 1 {
-                    return Err(Error::new(
-                        item.ident.span(),
-                        "#[memdev(byte, ...)] must be used on a struct with exactly 1 \
-                        field of type u8",
-                    ));
-                }
-                let field = &fields.named[0];
-                check_type_u8(&field.ty)?;
-                let name = field.ident.as_ref().unwrap();
-                quote! { #name }
-            }
-            syn::Fields::Unnamed(fields) => {
-                if fields.unnamed.len() != 1 {
-                    return Err(Error::new(
-                        item.ident.span(),
-                        "#[memdev(byte, ...)] must be used on a struct with exactly 1 \
-                        field of type u8",
-                    ));
-                }
-                let field = &fields.unnamed[0];
-                check_type_u8(&field.ty)?;
-                quote! { 0 }
-            }
-            syn::Fields::Unit => {
-                return Err(Error::new(
-                    item.ident.span(),
-                    "#[memdev(byte, ...)] does not work on unit structs. Must be a struct \
-                    with exactly 1 field of type u8",
-                ))
-            }
-        },
-        _ => {
-            return Err(Error::new(
-                item.ident.span(),
-                "#[memdev(byte, ...)] only works on structs",
-            ))
-        }
-    };
-
     let feo3boy = get_crate("feo3boy");
     let ty = &item.ident;
-    let readable = match &wrapper.readwrite.readable {
-        Some((_, readable)) => readable.value.to_token_stream(),
-        None => quote! { 0xffu8 },
-    };
-    let writable = match &wrapper.readwrite.writable {
-        Some((_, writable)) => writable.value.to_token_stream(),
-        None => quote! { 0xffu8 },
-    };
+    let read = &wrapper.read.value;
+    let write = &wrapper.write.value;
 
     Ok(quote! {
         impl #feo3boy::memdev::MemDevice for #ty {
-            fn read(&self, addr: #feo3boy::memdev::Addr) -> u8 {
-                const READABLE_BITS: u8 = #readable;
+            const LEN: usize = 1;
 
-                assert!(
-                    addr.index() == 0,
-                    concat!("Address {} out of range for ", stringify!(#ty)),
-                    addr
-                );
-                self.#field & READABLE_BITS | !READABLE_BITS
+            fn read_byte_relative(&self, addr: #feo3boy::memdev::RelativeAddr) -> u8 {
+                #feo3boy::check_addr!(#ty, addr);
+                #read(self)
             }
 
-            fn write(&mut self, addr: #feo3boy::memdev::Addr, val: u8) {
-                const WRITABLE_BITS: u8 = #writable;
+            fn write_byte_relative(&mut self, addr: #feo3boy::memdev::RelativeAddr, val: u8) {
+                #feo3boy::check_addr!(#ty, addr);
+                #write(self, val)
+            }
 
-                assert!(
-                    addr.index() == 0,
-                    concat!("Address {} out of range for ", stringify!(#ty)),
-                    addr
-                );
-                self.#field = (self.#field & !WRITABLE_BITS) | (val & WRITABLE_BITS)
+            fn read_bytes_relative(&self, addr: #feo3boy::memdev::RelativeAddr, data: &mut [u8]) {
+                #feo3boy::check_addr!(#ty, addr, data.len());
+                match data.first_mut() {
+                    Some(data) => *data = #read(self),
+                    None => {}
+                }
+            }
+
+            fn write_bytes_relative(&mut self, addr: #feo3boy::memdev::RelativeAddr, data: &[u8]) {
+                #feo3boy::check_addr!(#ty, addr, data.len());
+                match data.first().copied() {
+                    Some(val) => #write(self, val),
+                    None => {}
+                }
             }
         }
     })
-}
-
-/// Verify that the given ty is a path type with ident `u8`.
-fn check_type_u8(ty: &Type) -> Result<()> {
-    match ty {
-        Type::Path(p) if p.qself.is_none() && p.path.is_ident("u8") => Ok(()),
-        _ => Err(Error::new_spanned(
-            ty,
-            "Type of the field of a #[memdev(byte, ...)] must be u8.",
-        )),
-    }
 }

--- a/feo3boy-memdev-derive/src/device_type.rs
+++ b/feo3boy-memdev-derive/src/device_type.rs
@@ -9,11 +9,14 @@ use syn::{DeriveInput, Error, Expr, Meta, Result, Token};
 #[derive(Parse)]
 pub enum DeviceType {
     /// The type is a wrapper around a single byte.
-    #[peek(kw::byte, name = "ByteWrapper")]
-    ByteWrapper(ByteWrapper),
+    #[peek(kw::bits, name = "BitsWrapper")]
+    BitsWrapper(BitsWrapper),
     /// The type is a wrapper around bitflags.
     #[peek(kw::bitflags, name = "BitFlags")]
     BitFlags(BitFlags),
+    /// The type is a wrapper around bitflags.
+    #[peek(kw::byte, name = "ByteWrapper")]
+    ByteWrapper(ByteWrapper),
     /// Passthrough mem device.
     #[peek(kw::passthrough, name = "PassThrough")]
     Passthrough(kw::passthrough),
@@ -69,11 +72,11 @@ impl DeviceType {
     }
 }
 
-/// Contents of the `#[memdev(byte, readable = ..., writable = ...)]` expression.
+/// Contents of the `#[memdev(bits, readable = ..., writable = ...)]` expression.
 #[derive(Parse)]
-pub struct ByteWrapper {
-    /// The byte token that starts this expression.
-    pub byte: kw::byte,
+pub struct BitsWrapper {
+    /// The bits token that starts this expression.
+    pub byte: kw::bits,
     /// The values for the `readable = ...`  and `writable = ...` inputs.
     pub readwrite: ReadableWritable,
 }
@@ -119,16 +122,48 @@ pub struct Readable {
 /// The sequence `readable = <expr>`.
 #[derive(Parse)]
 pub struct Writable {
-    pub readable: kw::writable,
+    pub writable: kw::writable,
+    pub equals: Token![=],
+    pub value: Expr,
+}
+
+/// Contests of the `#[memdev(byte, read = ..., write = ...)]` expression.
+#[derive(Parse)]
+pub struct ByteWrapper {
+    /// The byte token that starts this expression.
+    pub byte: kw::byte,
+    pub comma1: Token![,],
+    /// The value set for "read".
+    pub read: Read,
+    pub comma2: Token![,],
+    /// The value set for "write".
+    pub write: Write,
+}
+
+/// The sequence `read = <expr>`.
+#[derive(Parse)]
+pub struct Read {
+    pub read: kw::read,
+    pub equals: Token![=],
+    pub value: Expr,
+}
+
+/// The sequence `readable = <expr>`.
+#[derive(Parse)]
+pub struct Write {
+    pub write: kw::write,
     pub equals: Token![=],
     pub value: Expr,
 }
 
 mod kw {
-    syn::custom_keyword!(byte);
+    syn::custom_keyword!(bits);
     syn::custom_keyword!(bitflags);
+    syn::custom_keyword!(byte);
     syn::custom_keyword!(passthrough);
 
     syn::custom_keyword!(readable);
+    syn::custom_keyword!(read);
     syn::custom_keyword!(writable);
+    syn::custom_keyword!(write);
 }

--- a/feo3boy-memdev-derive/src/lib.rs
+++ b/feo3boy-memdev-derive/src/lib.rs
@@ -6,6 +6,7 @@ use syn::{DeriveInput, Result};
 use crate::device_type::DeviceType;
 
 mod bitflags;
+mod bitswrapper;
 mod bytewrapper;
 mod device_type;
 mod passthrough;
@@ -41,8 +42,9 @@ fn build_memdev_derives(item: &DeriveInput) -> Result<TokenStream> {
     let device_type = DeviceType::extract_from(item)?;
 
     match device_type {
-        DeviceType::ByteWrapper(ref wrapper) => bytewrapper::build_byte_wrapper(item, wrapper),
+        DeviceType::BitsWrapper(ref wrapper) => bitswrapper::build_bits_wrapper(item, wrapper),
         DeviceType::BitFlags(ref flags) => bitflags::build_flags(item, flags),
+        DeviceType::ByteWrapper(ref wrapper) => bytewrapper::build_byte_wrapper(item, wrapper),
         DeviceType::Passthrough(_) => passthrough::build_passthrough(item),
     }
 }

--- a/feo3boy/Cargo.toml
+++ b/feo3boy/Cargo.toml
@@ -18,6 +18,8 @@ thiserror = "1"
 [dev-dependencies]
 env_logger = "0.10"
 criterion = "0.4"
+rand = "0.8"
+rand_pcg = "0.3"
 
 [[bench]]
 name = "opcodes"

--- a/feo3boy/src/gb.rs
+++ b/feo3boy/src/gb.rs
@@ -1,4 +1,3 @@
-
 use std::io::{self, Read, Write};
 
 use crate::apu::{self, ApuContext, ApuRegs, ApuState};
@@ -119,7 +118,6 @@ impl<E: Executor> ExecutorContext for Gb<E> {
         // TODO: run background processing while yielded.
         // Continue processing serial while yielded.
         input::update(self);
-        self.mmu.tick(4);
         serial::tick(self, 4);
         // apu must update before timer to catch falling edges from CPU writes
         apu::tick(self, 4);

--- a/feo3boy/src/gbz80core/direct_executor/args.rs
+++ b/feo3boy/src/gbz80core/direct_executor/args.rs
@@ -8,7 +8,7 @@ use feo3boy_opcodes::opcode::args::{AluOp, AluUnaryOp, ConditionCode, Operand16,
 use log::trace;
 
 use crate::gbz80core::direct_executor::{Ctx, Run, Runner};
-use crate::memdev::MemDevice;
+use crate::memdev::RootMemDevice;
 
 impl Runner for AluOp {}
 impl Runner for AluUnaryOp {}
@@ -31,50 +31,50 @@ impl Run<Operand8> {
             Operand8::AddrHL => {
                 let addr = ctx.cpu().regs.hl();
                 ctx.yield1m();
-                ctx.mem().read(addr.into())
+                ctx.mem().read_byte(addr)
             }
             Operand8::AddrBC => {
                 let addr = ctx.cpu().regs.bc();
                 ctx.yield1m();
-                ctx.mem().read(addr.into())
+                ctx.mem().read_byte(addr)
             }
             Operand8::AddrDE => {
                 let addr = ctx.cpu().regs.de();
                 ctx.yield1m();
-                ctx.mem().read(addr.into())
+                ctx.mem().read_byte(addr)
             }
             Operand8::AddrHLInc => {
                 let addr = ctx.cpu().regs.hl();
                 ctx.yield1m();
                 ctx.cpu_mut().regs.set_hl(addr.wrapping_add(1));
-                ctx.mem().read(addr.into())
+                ctx.mem().read_byte(addr)
             }
             Operand8::AddrHLDec => {
                 let addr = ctx.cpu().regs.hl();
                 ctx.yield1m();
                 ctx.cpu_mut().regs.set_hl(addr.wrapping_sub(1));
-                ctx.mem().read(addr.into())
+                ctx.mem().read_byte(addr)
             }
             Operand8::Immediate => {
                 let addr = ctx.cpu_mut().regs.pc;
                 ctx.cpu_mut().regs.pc = addr.wrapping_add(1);
                 ctx.yield1m();
-                ctx.mem().read(addr.into())
+                ctx.mem().read_byte(addr)
             }
             Operand8::AddrImmediate => {
                 let addr = Operand16::Immediate.runner().read(ctx);
                 ctx.yield1m();
-                ctx.mem().read(addr.into())
+                ctx.mem().read_byte(addr)
             }
             Operand8::AddrRelC => {
                 let addr = 0xFF00 + ctx.cpu().regs.c as u16;
                 ctx.yield1m();
-                ctx.mem().read(addr.into())
+                ctx.mem().read_byte(addr)
             }
             Operand8::AddrRelImmediate => {
                 let addr = 0xFF00 + Operand8::Immediate.runner().read(ctx) as u16;
                 ctx.yield1m();
-                ctx.mem().read(addr.into())
+                ctx.mem().read_byte(addr)
             }
         }
     }
@@ -93,45 +93,45 @@ impl Run<Operand8> {
             Operand8::AddrHL => {
                 let addr = ctx.cpu().regs.hl();
                 ctx.yield1m();
-                ctx.mem_mut().write(addr.into(), val)
+                ctx.mem_mut().write_byte(addr, val)
             }
             Operand8::AddrBC => {
                 let addr = ctx.cpu().regs.bc();
                 ctx.yield1m();
-                ctx.mem_mut().write(addr.into(), val)
+                ctx.mem_mut().write_byte(addr, val)
             }
             Operand8::AddrDE => {
                 let addr = ctx.cpu().regs.de();
                 ctx.yield1m();
-                ctx.mem_mut().write(addr.into(), val)
+                ctx.mem_mut().write_byte(addr, val)
             }
             Operand8::AddrHLInc => {
                 let addr = ctx.cpu().regs.hl();
                 ctx.yield1m();
                 ctx.cpu_mut().regs.set_hl(addr.wrapping_add(1));
-                ctx.mem_mut().write(addr.into(), val)
+                ctx.mem_mut().write_byte(addr, val)
             }
             Operand8::AddrHLDec => {
                 let addr = ctx.cpu().regs.hl();
                 ctx.yield1m();
                 ctx.cpu_mut().regs.set_hl(addr.wrapping_sub(1));
-                ctx.mem_mut().write(addr.into(), val)
+                ctx.mem_mut().write_byte(addr, val)
             }
             Operand8::Immediate => panic!("Immediates cannot be used as store destinations"),
             Operand8::AddrImmediate => {
                 let addr = Operand16::Immediate.runner().read(ctx);
                 ctx.yield1m();
-                ctx.mem_mut().write(addr.into(), val)
+                ctx.mem_mut().write_byte(addr, val)
             }
             Operand8::AddrRelC => {
                 let addr = 0xFF00 + ctx.cpu().regs.c as u16;
                 ctx.yield1m();
-                ctx.mem_mut().write(addr.into(), val)
+                ctx.mem_mut().write_byte(addr, val)
             }
             Operand8::AddrRelImmediate => {
                 let addr = 0xFF00 + Operand8::Immediate.runner().read(ctx) as u16;
                 ctx.yield1m();
-                ctx.mem_mut().write(addr.into(), val)
+                ctx.mem_mut().write_byte(addr, val)
             }
         }
     }
@@ -172,10 +172,10 @@ impl Run<Operand16> {
                 let [low, high] = val.to_le_bytes();
                 let mut addr = Wrapping(Operand16::Immediate.runner().read(ctx));
                 ctx.yield1m();
-                ctx.mem_mut().write(addr.0.into(), low);
+                ctx.mem_mut().write_byte(addr.0.into(), low);
                 addr += Wrapping(1u16);
                 ctx.yield1m();
-                ctx.mem_mut().write(addr.0.into(), high);
+                ctx.mem_mut().write_byte(addr.0.into(), high);
             }
         }
     }

--- a/feo3boy/src/gbz80core/direct_executor/mod.rs
+++ b/feo3boy/src/gbz80core/direct_executor/mod.rs
@@ -13,7 +13,7 @@ use crate::gbz80core::executor::Executor;
 use crate::gbz80core::oputils::halt;
 use crate::gbz80core::ExecutorContext;
 use crate::interrupts::Interrupts;
-use crate::memdev::MemDevice;
+use crate::memdev::RootMemDevice;
 
 mod args;
 mod tests;
@@ -360,12 +360,12 @@ fn push_helper(ctx: &mut impl Ctx, val: u16) {
     ctx.yield1m();
     let addr = ctx.cpu().regs.sp.wrapping_sub(1);
     ctx.cpu_mut().regs.sp = addr;
-    ctx.mem_mut().write(addr.into(), high);
+    ctx.mem_mut().write_byte(addr, high);
 
     ctx.yield1m();
     let addr = ctx.cpu().regs.sp.wrapping_sub(1);
     ctx.cpu_mut().regs.sp = addr;
-    ctx.mem_mut().write(addr.into(), low);
+    ctx.mem_mut().write_byte(addr, low);
 }
 
 /// Pop helper, shared between pop and ret. Pops value from the stack, waiting 1m between each byte
@@ -374,12 +374,12 @@ fn pop_helper(ctx: &mut impl Ctx) -> u16 {
     ctx.yield1m();
     let addr = ctx.cpu().regs.sp;
     ctx.cpu_mut().regs.sp = addr.wrapping_add(1);
-    let low = ctx.mem().read(addr.into());
+    let low = ctx.mem().read_byte(addr);
 
     ctx.yield1m();
     let addr = ctx.cpu().regs.sp;
     ctx.cpu_mut().regs.sp = addr.wrapping_add(1);
-    let high = ctx.mem().read(addr.into());
+    let high = ctx.mem().read_byte(addr);
 
     u16::from_le_bytes([low, high])
 }

--- a/feo3boy/src/gbz80core/direct_executor/tests.rs
+++ b/feo3boy/src/gbz80core/direct_executor/tests.rs
@@ -62,7 +62,7 @@ fn load8bit() {
             0x68..=0x6f => ctx.cpu_mut().regs.l = val,
             0x70..=0x77 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             0x78..=0x7f => ctx.cpu_mut().regs.acc = val,
             _ => unreachable!(),
@@ -78,7 +78,7 @@ fn load8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             0x7 => ctx.cpu_mut().regs.acc = val,
             _ => unreachable!(),
@@ -122,7 +122,7 @@ fn load8bit_immediate() {
             0x2e => ctx.cpu_mut().regs.l = val,
             0x36 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             0x3e => ctx.cpu_mut().regs.acc = val,
             _ => unreachable!(),
@@ -167,7 +167,7 @@ fn add8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -285,7 +285,7 @@ fn adc8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -410,7 +410,7 @@ fn sub8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -516,7 +516,7 @@ fn sbc8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -628,7 +628,7 @@ fn and8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -724,7 +724,7 @@ fn xor8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -818,7 +818,7 @@ fn or8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -914,7 +914,7 @@ fn cp8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }

--- a/feo3boy/src/gbz80core/microcode_executor/mod.rs
+++ b/feo3boy/src/gbz80core/microcode_executor/mod.rs
@@ -16,7 +16,7 @@ use crate::gbz80core::executor::{Executor, ExecutorState, PausePoint, SubInstruc
 use crate::gbz80core::oputils::halt;
 use crate::gbz80core::{ExecutorContext, InterruptMasterState};
 use crate::interrupts::Interrupts;
-use crate::memdev::{Addr, MemDevice};
+use crate::memdev::RootMemDevice;
 
 mod tests;
 
@@ -434,16 +434,16 @@ impl Run<Microcode> {
 
 /// Pop a 16 bit address and use it to read an 8 bit value from memory onto the stack.
 fn read_mem8(ctx: &mut impl Ctx) {
-    let addr = Addr::from(ctx.executor_mut().stack.popu16());
-    let val = ctx.mem().read(addr);
+    let addr = ctx.executor_mut().stack.popu16();
+    let val = ctx.mem().read_byte(addr);
     ctx.executor_mut().stack.pushu8(val);
 }
 
 /// Pop a 16 bit address and an 8 bit value and write the value to the address.
 fn write_mem8(ctx: &mut impl Ctx) {
-    let addr = Addr::from(ctx.executor_mut().stack.popu16());
+    let addr = ctx.executor_mut().stack.popu16();
     let val = ctx.executor_mut().stack.popu8();
-    ctx.mem_mut().write(addr, val);
+    ctx.mem_mut().write_byte(addr, val);
 }
 
 /// Internal implementation of microcode to fetch masked flags to the output.

--- a/feo3boy/src/gbz80core/microcode_executor/tests.rs
+++ b/feo3boy/src/gbz80core/microcode_executor/tests.rs
@@ -63,7 +63,7 @@ fn load8bit() {
             0x68..=0x6f => ctx.cpu_mut().regs.l = val,
             0x70..=0x77 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             0x78..=0x7f => ctx.cpu_mut().regs.acc = val,
             _ => unreachable!(),
@@ -79,7 +79,7 @@ fn load8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             0x7 => ctx.cpu_mut().regs.acc = val,
             _ => unreachable!(),
@@ -127,7 +127,7 @@ fn load8bit_immediate() {
             0x2e => ctx.cpu_mut().regs.l = val,
             0x36 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             0x3e => ctx.cpu_mut().regs.acc = val,
             _ => unreachable!(),
@@ -172,7 +172,7 @@ fn add8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -290,7 +290,7 @@ fn adc8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -415,7 +415,7 @@ fn sub8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -521,7 +521,7 @@ fn sbc8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -633,7 +633,7 @@ fn and8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -729,7 +729,7 @@ fn xor8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -823,7 +823,7 @@ fn or8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }
@@ -919,7 +919,7 @@ fn cp8bit() {
             0x5 => ctx.cpu_mut().regs.l = val,
             0x6 => {
                 let dest = ctx.cpu().regs.hl().into();
-                ctx.mem_mut().write(dest, val)
+                ctx.mem_mut().write_byte(dest, val)
             }
             _ => unreachable!(),
         }

--- a/feo3boy/src/gbz80core/mod.rs
+++ b/feo3boy/src/gbz80core/mod.rs
@@ -2,7 +2,7 @@ pub use feo3boy_opcodes::gbz80types::Flags;
 
 use crate::gbz80core::executor::ExecutorState;
 use crate::interrupts::{InterruptContext, MemInterrupts};
-use crate::memdev::{MemContext, MemDevice};
+use crate::memdev::{MemContext, MemDevice, RootExtend};
 
 pub mod direct_executor;
 pub mod executor;
@@ -210,25 +210,25 @@ impl<M> CpuContext for (Gbz80State, M) {
 }
 
 impl<M: MemDevice> MemContext for (Gbz80State, M) {
-    type Mem = M;
+    type Mem = RootExtend<M>;
 
     #[inline]
     fn mem(&self) -> &Self::Mem {
-        &self.1
+        RootExtend::wrap_ref(&self.1)
     }
 
     #[inline]
     fn mem_mut(&mut self) -> &mut Self::Mem {
-        &mut self.1
+        RootExtend::wrap_mut(&mut self.1)
     }
 }
 
 impl<M: MemDevice> InterruptContext for (Gbz80State, M) {
-    type Interrupts = MemInterrupts<M>;
+    type Interrupts = MemInterrupts<RootExtend<M>>;
 
     #[inline]
     fn interrupts(&self) -> &Self::Interrupts {
-        MemInterrupts::wrap(self.mem())
+        MemInterrupts::wrap_ref(self.mem())
     }
 
     #[inline]
@@ -271,25 +271,25 @@ impl<M> CpuContext for (&mut Gbz80State, &mut M) {
 }
 
 impl<M: MemDevice> MemContext for (&mut Gbz80State, &mut M) {
-    type Mem = M;
+    type Mem = RootExtend<M>;
 
     #[inline]
     fn mem(&self) -> &Self::Mem {
-        self.1
+        RootExtend::wrap_ref(self.1)
     }
 
     #[inline]
     fn mem_mut(&mut self) -> &mut Self::Mem {
-        self.1
+        RootExtend::wrap_mut(self.1)
     }
 }
 
 impl<M: MemDevice> InterruptContext for (&mut Gbz80State, &mut M) {
-    type Interrupts = MemInterrupts<M>;
+    type Interrupts = MemInterrupts<RootExtend<M>>;
 
     #[inline]
     fn interrupts(&self) -> &Self::Interrupts {
-        MemInterrupts::wrap(self.mem())
+        MemInterrupts::wrap_ref(self.mem())
     }
 
     #[inline]
@@ -331,25 +331,25 @@ impl<M, S> CpuContext for (Gbz80State, M, S) {
 }
 
 impl<M: MemDevice, S> MemContext for (Gbz80State, M, S) {
-    type Mem = M;
+    type Mem = RootExtend<M>;
 
     #[inline]
     fn mem(&self) -> &Self::Mem {
-        &self.1
+        RootExtend::wrap_ref(&self.1)
     }
 
     #[inline]
     fn mem_mut(&mut self) -> &mut Self::Mem {
-        &mut self.1
+        RootExtend::wrap_mut(&mut self.1)
     }
 }
 
 impl<M: MemDevice, S> InterruptContext for (Gbz80State, M, S) {
-    type Interrupts = MemInterrupts<M>;
+    type Interrupts = MemInterrupts<RootExtend<M>>;
 
     #[inline]
     fn interrupts(&self) -> &Self::Interrupts {
-        MemInterrupts::wrap(self.mem())
+        MemInterrupts::wrap_ref(self.mem())
     }
 
     #[inline]
@@ -391,25 +391,25 @@ impl<M: MemDevice, S> CpuContext for (&mut Gbz80State, &mut M, &mut S) {
 }
 
 impl<M: MemDevice, S> MemContext for (&mut Gbz80State, &mut M, &mut S) {
-    type Mem = M;
+    type Mem = RootExtend<M>;
 
     #[inline]
     fn mem(&self) -> &Self::Mem {
-        self.1
+        RootExtend::wrap_ref(self.1)
     }
 
     #[inline]
     fn mem_mut(&mut self) -> &mut Self::Mem {
-        self.1
+        RootExtend::wrap_mut(self.1)
     }
 }
 
 impl<M: MemDevice, S> InterruptContext for (&mut Gbz80State, &mut M, &mut S) {
-    type Interrupts = MemInterrupts<M>;
+    type Interrupts = MemInterrupts<RootExtend<M>>;
 
     #[inline]
     fn interrupts(&self) -> &Self::Interrupts {
-        MemInterrupts::wrap(self.mem())
+        MemInterrupts::wrap_ref(self.mem())
     }
 
     #[inline]

--- a/feo3boy/src/macros.rs
+++ b/feo3boy/src/macros.rs
@@ -2,54 +2,350 @@
 //! before the module they are used in (one of the few cases of declaration
 //! order-dependence in Rust).
 
+/// Build a MemDevice from fields of a struct.
 #[macro_export]
 macro_rules! memdev_fields {
-    ($ty:ident {
+    ($ty:ident, len: $len:literal, {
         $($start:literal $(..= $end:literal)? => $target:tt,)*
     }) => {
         impl $crate::memdev::MemDevice for $ty {
-            fn read(&self, addr: $crate::memdev::Addr) -> u8 {
-                match addr.relative() {
-                    $($start $(..= $end)? => memdev_fields!(@reader: self, addr.offset_by($start), $target),)*
-                    _ => panic!(concat!("Address {} out of range for ", stringify!($ty)), addr),
-                }
+            const LEN: usize = $len;
+
+            fn read_byte_relative(&self, addr: $crate::memdev::RelativeAddr) -> u8 {
+                $crate::dispatch_memdev_byte!($ty, addr, |addr| {
+                    $($start $(..= $end)? => $crate::memdev_fields!(@reader: self, addr, $target),)*
+                })
             }
 
-            fn write(&mut self, addr: $crate::memdev::Addr, val: u8) {
-                match addr.relative() {
-                    $($start $(..= $end)? => memdev_fields!(@writer: self, addr.offset_by($start), val, $target),)*
-                    _ => panic!(concat!("Address {} out of range for ", stringify!($ty)), addr),
-                }
+            fn read_bytes_relative(&self, addr: $crate::memdev::RelativeAddr, data: &mut [u8]) {
+                $crate::dispatch_memdev_bytes!($ty, addr, data, |addr, mut data| {
+                    $($start $(..= $end)? => {
+                        $crate::memdev_fields!(@range_reader: self, addr, data, $target)
+                    },)*
+                })
+            }
+
+            fn write_byte_relative(&mut self, addr: $crate::memdev::RelativeAddr, val: u8) {
+                $crate::dispatch_memdev_byte!($ty, addr, |addr| {
+                    $($start $(..= $end)? => $crate::memdev_fields!(@writer: self, addr, val, $target),)*
+                })
+            }
+
+            fn write_bytes_relative(&mut self, addr: $crate::memdev::RelativeAddr, data: &[u8]) {
+                $crate::dispatch_memdev_bytes!($ty, addr, data, |addr, ref data| {
+                    $($start $(..= $end)? => {
+                        $crate::memdev_fields!(@range_writer: self, addr, data, $target)
+                    },)*
+                });
             }
         }
     };
 
     (@reader: $self:ident, $addr:expr, $target:ident) => {
-        $crate::memdev::MemDevice::read(&$self.$target, $addr)
+        $crate::memdev::MemDevice::read_byte_relative(&$self.$target, $addr)
     };
     (@reader: $self:ident, $addr:expr, $target:literal) => {
         $target
     };
     (@reader: $self:ident, $addr:expr, { $target:ident, skip_over: $skip:literal }) => {
-        $crate::memdev::MemDevice::read(&$self.$target, $addr.skip_over($skip))
+        $crate::memdev_fields!(@reader: $self, $addr.skip_over($skip), $target)
     };
     (@reader: $self:ident, $addr:expr, { $target:ident, readonly }) => {
-        memdev_fields!(@reader: $self, $addr, $target)
+        $crate::memdev_fields!(@reader: $self, $addr, $target)
+    };
+
+    (@range_reader: $self:ident, $addr:expr, $data:ident, $target:ident) => {
+        $crate::memdev::MemDevice::read_bytes_relative(&$self.$target, $addr, $data)
+    };
+    (@range_reader: $self:ident, $addr:expr, $data:ident, $target:literal) => {
+        $data.fill($target)
+    };
+    (@range_reader: $self:ident, $addr:expr, $data:ident, { $target:ident, skip_over: $skip:literal }) => {
+        $crate::memdev_fields!(@range_reader: $self, $addr.skip_over($skip), $data, $target)
+    };
+    (@range_reader: $self:ident, $addr:expr, $data:ident, { $target:ident, readonly }) => {
+        $crate::memdev_fields!(@range_reader: $self, $addr, $data, $target)
     };
 
     (@writer: $self:ident, $addr:expr, $val:ident, $target:ident) => {
-        $crate::memdev::MemDevice::write(&mut $self.$target, $addr, $val)
+        $crate::memdev::MemDevice::write_byte_relative(&mut $self.$target, $addr, $val)
     };
     (@writer: $self:ident, $addr:expr, $val:ident, $target:literal) => {
         ()
     };
     (@writer: $self:ident, $addr:expr, $val:ident, { $target:ident, skip_over: $skip:literal }) => {
-        $crate::memdev::MemDevice::write(&mut $self.$target, $addr.skip_over($skip), $val)
+        $crate::memdev_fields!(@writer: $self, $addr.skip_over($skip), $val, $target)
     };
     (@writer: $self:ident, $addr:expr, $val:ident, { $target:ident, readonly }) => {
         ()
     };
 
+    (@range_writer: $self:ident, $addr:expr, $data:ident, $target:ident) => {
+        $crate::memdev::MemDevice::write_bytes_relative(&mut $self.$target, $addr, $data)
+    };
+    (@range_writer: $self:ident, $addr:expr, $data:ident, $target:literal) => {
+        ()
+    };
+    (@range_writer: $self:ident, $addr:expr, $data:ident, { $target:ident, skip_over: $skip:literal }) => {
+        $crate::memdev_fields!(@range_writer: $self, $addr.skip_over($skip), $data, $target)
+    };
+    (@range_writer: $self:ident, $addr:expr, $data:ident, { $target:ident, readonly }) => {
+        ()
+    };
+
     (@addr: $base:ident, $addr:tt) => { $base.offset_by($addr) };
     (@addr: $base:ident, $addr:literal..=$end:literal) => { $base.offset_by($addr) };
+}
+
+/// Dispatch a memdev read/write for a single byte to handlers based on their address.
+///
+/// usage:
+/// ```
+/// # use feo3boy::memdev::{MemDevice, RelativeAddr};
+/// # use feo3boy::{dispatch_memdev_bytes, dispatch_memdev_byte};
+/// # struct MyType(u8, [u8; 3]);
+/// # impl MemDevice for MyType {
+/// # const LEN: usize = 5;
+/// # fn read_bytes_relative(&self, addr: RelativeAddr, data: &mut [u8]) {
+/// #     dispatch_memdev_bytes!(MyType, addr, data, |addr, mut data| {
+/// #         0x00 => data[0] = self.0.read_byte_relative(addr),
+/// #         0x01..=0x04 => self.1.read_bytes_relative(addr, data),
+/// #     })
+/// # }
+/// #
+/// fn read_byte_relative(&self, addr: RelativeAddr) -> u8 {
+///     dispatch_memdev_byte!(MyType, addr, |addr| {
+///         0x00 => self.0.read_byte_relative(addr),
+///         0x01..=0x04 => self.1.read_byte_relative(addr),
+///     })
+/// }
+/// #
+/// # fn write_bytes_relative(&mut self, addr: RelativeAddr, data: &[u8]) {
+/// #     dispatch_memdev_bytes!(MyType, addr, data, |addr, ref data| {
+/// #         0x00 => self.0.write_byte_relative(addr, data[0]),
+/// #         0x01..=0x04 => self.1.write_bytes_relative(addr, data),
+/// #     })
+/// # }
+///
+/// fn write_byte_relative(&mut self, addr: RelativeAddr, val: u8) {
+///     dispatch_memdev_byte!(MyType, addr, |addr| {
+///         0x00 => self.0.write_byte_relative(addr, val),
+///         0x01..=0x04 => self.1.write_byte_relative(addr, val),
+///     })
+/// }
+/// # }
+/// ```
+///
+/// The first argument should be the name of the type being implemented. The second
+/// argument is an identifier for the address pased to
+/// `read_byte_relative`/`write_byte_relative`.
+///
+/// The section in `||` defines the field that will be available to the code in the block
+/// that matches each range being dispatched.  This must always be exactly one identifier
+/// which will be filled with the offset-addr for the matched block.
+///
+/// The addr provided to the handler for a given address range be the address being
+/// read-from `offset_by` the address of the start of the matched range. This means you do
+/// not need to use `offset_by` with this macro, which reduces the risk of error relaative
+/// to writing this match block yourself. You may still choose to use skip_over if mapping
+/// in a block of memory oddly.
+///
+/// The generated dispatch operation will panic if the slice overflows the mapping in the
+/// mem device or if an un-mapped are is encountered.
+#[macro_export]
+macro_rules! dispatch_memdev_byte {
+    ($dev:ty, $addr:ident, |$outaddr:ident| {
+        $($start:literal $(..= $end:literal)? $(if $cond:expr)? => $target:expr,)*
+    }) => {{
+        let addr: $crate::memdev::RelativeAddr = $addr;
+        // Block use of the $addr identifier in this block. This is
+        // to prevent an easy-to-make mistake where you use the wrong ident
+        // and read from the un-offset address rather than the offset one.
+        #[allow(unused)]
+        let $addr = ();
+        $crate::check_addr!($dev, addr);
+        match addr.relative() {
+            $($start $(..= $end)? $(if $cond)? => {
+                #[allow(unused)]
+                let $outaddr = addr.offset_by($start);
+                { $target }
+            })*
+            #[allow(unreachable_patterns)]
+            _ => panic!(concat!("Unmapped Address {} in device ", stringify!($dev)), addr),
+        }
+    }};
+}
+
+/// Dispatch a memdev read/write over multiple bytes to handlers based on their address.
+///
+/// usage:
+/// ```
+/// # use feo3boy::memdev::{MemDevice, RelativeAddr};
+/// # use feo3boy::{dispatch_memdev_bytes, dispatch_memdev_byte};
+/// # struct MyType(u8, [u8; 4]);
+/// # impl MemDevice for MyType {
+/// # const LEN: usize = 5;
+/// fn read_bytes_relative(&self, addr: RelativeAddr, data: &mut [u8]) {
+///     dispatch_memdev_bytes!(MyType, addr, data, |addr, mut data| {
+///         0x00 => data[0] = self.0.read_byte_relative(addr),
+///         0x01..=0x04 => self.1.read_bytes_relative(addr, data),
+///     })
+/// }
+///
+/// fn write_bytes_relative(&mut self, addr: RelativeAddr, data: &[u8]) {
+///     dispatch_memdev_bytes!(MyType, addr, data, |addr, ref data| {
+///         0x00 => self.0.write_byte_relative(addr, data[0]),
+///         0x01..=0x04 => self.1.write_bytes_relative(addr, data),
+///     })
+/// }
+/// # }
+/// ```
+///
+/// The first argument should be the name of the type being implemented. The second
+/// argument is an identifier for the address pased to
+/// `read_bytes_relative`/`write_bytes_relative`. The third argument is the identifier for
+/// the `data` argument passed to the method.
+///
+/// The section in `||` defines the fields that will be available to the code in the block
+/// that matches each range being dispatched.  This must always be two identifiers: the
+/// first one will be provided with the address of the read to that segment, offset to the
+/// start of the range being matched. The second argument is the original data, sliced to
+/// the portion corresponding to the range being read/written. The `data` slice can have
+/// an optional `mut` modifier which will cause it to be re-sliced mutably rather than
+/// immutably.
+///
+/// The data provided to the dispatch range is guaranteed to be non-empty, and will not
+/// exceed the size of the range specified.
+///
+/// The addr provided to the handler for a given address range will vary slightly
+/// depending on whether this is the first segment being read. If it is the first segment,
+/// the address provided will be the address of the original read, `offset_by` the start
+/// address of the segment that was matched. If it is one of the other segments, then the
+/// address provided will be the address of that segment `offset_by` the address of the
+/// segment. In either case, the address will already be offset by the start of the
+/// address range being read from.
+///
+/// The generated dispatch operation will panic if the slice overflows the mapping in the
+/// mem device or if an un-mapped are is encountered.
+#[macro_export]
+macro_rules! dispatch_memdev_bytes {
+    ($dev:ty, $addr:ident, $data:ident, |$outaddr:ident, $refmut:tt $outdata:ident| {
+        $($start:literal $(..= $end:literal)? $(if $cond:expr)? => $target:expr,)*
+    }) => {{
+        let orig_data = $data;
+        // `addr` is always the address we are reading from relative to the start of
+        // *this* mem device. It starts out as the requested read address, and then after
+        // reading a subset of data, it will be moved to the address of the next segement
+        // to match on.
+        let mut addr: $crate::memdev::RelativeAddr = $addr;
+        let mut data_len: usize = orig_data.len();
+        // Block use of the $addr and $data identifiers in this block. This is
+        // to prevent an easy-to-make mistake where you use the wrong ident
+        // and read from the *whole* data instead of the subslice.
+        #[allow(unused)]
+        let $addr = ();
+        #[allow(unused)]
+        let $data = ();
+        $crate::check_addr!($dev, addr, data_len);
+        let mut start = 0;
+        while data_len > 0 {
+            match addr.relative() {
+                $($start $(..= $end)? $(if $cond)? => {
+                           // Number of bytes available in what is left of this range.
+                    let available = ($crate::dispatch_memdev_bytes!(@get_end: $start $(..= $end)?) - addr.relative() + 1) as usize;
+                    // Number of bytes we will actually read this iteration.
+                    let read = available.min(data_len);
+                    // Decrease the number of bytes remaining based on how many we will
+                    // read this iteration.
+                    data_len -= read;
+                    // Compute the range of the input data that is actually being read and
+                    // update the start for next time.
+                    let end_exclusive = start+read;
+                    let datarange = start..end_exclusive;
+
+                    #[allow(unused)]
+                    let $outaddr = addr.offset_by($start);
+                    #[allow(unused)]
+                    let $outdata = $crate::dispatch_memdev_bytes!(@slicedata: $refmut orig_data[datarange]);
+
+                    start = end_exclusive;
+                    // We use move_forward_by_wrapping rather than move_forward_by becuase
+                    // if we are reading 0xffff, we don't want to crash when incrementing.
+                    // If the read covers the full range, this will just end up moving
+                    // forward by 0, but that's fine becuase there will be nothing left to
+                    // read afterward, so we will break before reading from the same spot
+                    // again.
+                    addr = addr.move_forward_by_wrapping(read as u16);
+
+                    { $target; }
+                })*
+                #[allow(unreachable_patterns)]
+                _ => panic!(concat!("Unmapped Address {} in device ", stringify!($dev)), addr),
+            }
+        }
+    }};
+
+    (@get_end: $start:literal) => { $start };
+    (@get_end: $start:literal ..= $end:literal) => { $end };
+
+    (@slicedata: mut $sliced:expr) => { &mut $sliced };
+    (@slicedata: ref $sliced:expr) => { &$sliced };
+}
+
+/// Assert that the address is in range for a MemDevice. Takes two args, the first is a
+/// MemDevice type, the second is the identifier for an Addr. Note that the MemDevice
+/// should be the explicit type rather than Self for the device type to get better error
+/// messages.
+#[macro_export]
+macro_rules! check_addr {
+    ($dev:ty, $addr:ident) => {
+        assert!(
+            $addr.index() < <$dev as $crate::memdev::MemDevice>::LEN,
+            concat!("Address {} out of range for ", stringify!($dev)),
+            $addr,
+        );
+    };
+    ($dev:ty, $addr:ident, $len:expr) => {{
+        let len = $len;
+        assert!(
+            $crate::memdev::RangeOverlaps::encloses(
+                &(0..<$dev as $crate::memdev::MemDevice>::LEN),
+                &$addr.range(len),
+            ),
+            concat!(
+                "Address {} + slice of length {} not fully enclosed by ",
+                stringify!($dev)
+            ),
+            $addr,
+            len,
+        );
+    }};
+}
+
+/// Implement the memdev range functions from the single-byte reader functions. This
+/// effectively does the reverse of the default implementation of read_byte_relative.
+#[macro_export]
+macro_rules! memdev_bytes_from_byte {
+    ($dev:ty) => {
+        fn read_bytes_relative(&self, addr: $crate::memdev::RelativeAddr, data: &mut [u8]) {
+            $crate::check_addr!($dev, addr, data.len());
+            for (offset, dest) in data.iter_mut().enumerate() {
+                *dest = $crate::memdev::MemDevice::read_byte_relative(
+                    self,
+                    addr.move_forward_by(offset as u16),
+                );
+            }
+        }
+
+        fn write_bytes_relative(&mut self, addr: $crate::memdev::RelativeAddr, data: &[u8]) {
+            $crate::check_addr!($dev, addr, data.len());
+            for (offset, source) in data.iter().enumerate() {
+                $crate::memdev::MemDevice::write_byte_relative(
+                    self,
+                    addr.move_forward_by(offset as u16),
+                    *source,
+                );
+            }
+        }
+    };
 }

--- a/feo3boy/src/memdev/cartridge.rs
+++ b/feo3boy/src/memdev/cartridge.rs
@@ -8,7 +8,12 @@ use std::slice;
 use log::warn;
 use thiserror::Error;
 
-use super::{Addr, MemDevice, NullRom, ReadOnly};
+use super::{MemDevice, NullRom, ReadOnly, RelativeAddr};
+
+/// Length of a cartridge in bytes, counting both ram and rom. This counts the number of
+/// bytes in ram/rom contiguously. The gap between ram and rom only exists in how the
+/// cartridge memory space is mapped into memory by the memory manager.
+const CART_MEMDEV_LEN: usize = 0xA000;
 
 /// Errors that can result from attempting to parse a cartridge dump.
 #[derive(Debug, Error)]
@@ -310,21 +315,41 @@ impl TryFrom<Vec<u8>> for Cartridge {
 }
 
 impl MemDevice for Cartridge {
-    fn read(&self, addr: Addr) -> u8 {
+    const LEN: usize = CART_MEMDEV_LEN;
+
+    fn read_byte_relative(&self, addr: RelativeAddr) -> u8 {
         match self {
-            Cartridge::None => NullRom::<0xA000>.read(addr),
-            Cartridge::RomOnly(ref cart) => cart.read(addr),
-            Cartridge::Mbc1(ref cart) => cart.read(addr),
-            Cartridge::Mbc3(ref cart) => cart.read(addr),
+            Cartridge::None => NullRom::<CART_MEMDEV_LEN>.read_byte_relative(addr),
+            Cartridge::RomOnly(ref cart) => cart.read_byte_relative(addr),
+            Cartridge::Mbc1(ref cart) => cart.read_byte_relative(addr),
+            Cartridge::Mbc3(ref cart) => cart.read_byte_relative(addr),
         }
     }
 
-    fn write(&mut self, addr: Addr, value: u8) {
+    fn read_bytes_relative(&self, addr: RelativeAddr, data: &mut [u8]) {
         match self {
-            Cartridge::None => NullRom::<0xA000>.write(addr, value),
-            Cartridge::RomOnly(ref mut cart) => cart.write(addr, value),
-            Cartridge::Mbc1(ref mut cart) => cart.write(addr, value),
-            Cartridge::Mbc3(ref mut cart) => cart.write(addr, value),
+            Cartridge::None => NullRom::<CART_MEMDEV_LEN>.read_bytes_relative(addr, data),
+            Cartridge::RomOnly(ref cart) => cart.read_bytes_relative(addr, data),
+            Cartridge::Mbc1(ref cart) => cart.read_bytes_relative(addr, data),
+            Cartridge::Mbc3(ref cart) => cart.read_bytes_relative(addr, data),
+        }
+    }
+
+    fn write_byte_relative(&mut self, addr: RelativeAddr, value: u8) {
+        match self {
+            Cartridge::None => NullRom::<CART_MEMDEV_LEN>.write_byte_relative(addr, value),
+            Cartridge::RomOnly(ref mut cart) => cart.write_byte_relative(addr, value),
+            Cartridge::Mbc1(ref mut cart) => cart.write_byte_relative(addr, value),
+            Cartridge::Mbc3(ref mut cart) => cart.write_byte_relative(addr, value),
+        }
+    }
+
+    fn write_bytes_relative(&mut self, addr: RelativeAddr, data: &[u8]) {
+        match self {
+            Cartridge::None => NullRom::<CART_MEMDEV_LEN>.write_bytes_relative(addr, data),
+            Cartridge::RomOnly(ref mut cart) => cart.write_bytes_relative(addr, data),
+            Cartridge::Mbc1(ref mut cart) => cart.write_bytes_relative(addr, data),
+            Cartridge::Mbc3(ref mut cart) => cart.write_bytes_relative(addr, data),
         }
     }
 }
@@ -382,8 +407,20 @@ pub struct RomOnly {
 }
 
 impl RomOnly {
+    pub fn new(
+        rom_banks: Box<[RomBank; 2]>,
+        ram_bank: Option<Box<RamBank>>,
+        save_ram: bool,
+    ) -> Self {
+        Self {
+            rom_banks,
+            ram_bank,
+            save_ram,
+        }
+    }
+
     /// Constructs a new `RomOnly` with empty (all 0) rom banks and no ram bank.
-    fn empty() -> Self {
+    pub fn empty() -> Self {
         Self {
             rom_banks: Box::new([ReadOnly([0u8; ROM_BANK_SIZE]); 2]),
             ram_bank: None,
@@ -393,28 +430,50 @@ impl RomOnly {
 }
 
 impl MemDevice for RomOnly {
-    fn read(&self, addr: Addr) -> u8 {
-        match addr.relative() {
-            0..=0x3fff => self.rom_banks[0].read(addr),
-            0x4000..=0x7fff => self.rom_banks[1].read(addr.offset_by(0x4000)),
+    const LEN: usize = CART_MEMDEV_LEN;
+
+    fn read_byte_relative(&self, addr: RelativeAddr) -> u8 {
+        dispatch_memdev_byte!(RomOnly, addr, |addr| {
+            0..=0x3fff => self.rom_banks[0].read_byte_relative(addr),
+            0x4000..=0x7fff => self.rom_banks[1].read_byte_relative(addr),
             0x8000..=0x9fff => match self.ram_bank {
-                Some(ref ram) => ram.read(addr.offset_by(0x8000)),
-                None => 0,
+                Some(ref ram) => ram.read_byte_relative(addr),
+                None => 0xff,
             },
-            _ => panic!("Address {} out of range for Mbc1Rom", addr),
-        }
+        })
     }
 
-    fn write(&mut self, addr: Addr, value: u8) {
-        match addr.relative() {
-            0..=0x3fff => self.rom_banks[0].write(addr, value),
-            0x4000..=0x7fff => self.rom_banks[1].write(addr.offset_by(0x4000), value),
+    fn read_bytes_relative(&self, addr: RelativeAddr, data: &mut [u8]) {
+        dispatch_memdev_bytes!(RomOnly, addr, data, |addr, mut data| {
+            0..=0x3fff => self.rom_banks[0].read_bytes_relative(addr, data),
+            0x4000..=0x7fff => self.rom_banks[1].read_bytes_relative(addr, data),
             0x8000..=0x9fff => match self.ram_bank {
-                Some(ref mut ram) => ram.write(addr.offset_by(0x8000), value),
+                Some(ref ram) => ram.read_bytes_relative(addr, data),
+                None => data.fill(0xff),
+            },
+        })
+    }
+
+    fn write_byte_relative(&mut self, addr: RelativeAddr, value: u8) {
+        dispatch_memdev_byte!(RomOnly, addr, |addr| {
+            0..=0x3fff => self.rom_banks[0].write_byte_relative(addr, value),
+            0x4000..=0x7fff => self.rom_banks[1].write_byte_relative(addr, value),
+            0x8000..=0x9fff => match self.ram_bank {
+                Some(ref mut ram) => ram.write_byte_relative(addr, value),
                 None => {}
             },
-            _ => panic!("Address {} out of range for Mbc1Rom", addr),
-        }
+        })
+    }
+
+    fn write_bytes_relative(&mut self, addr: RelativeAddr, data: &[u8]) {
+        dispatch_memdev_bytes!(RomOnly, addr, data, |addr, ref data| {
+            0..=0x3fff => self.rom_banks[0].write_bytes_relative(addr, data),
+            0x4000..=0x7fff => self.rom_banks[1].write_bytes_relative(addr, data),
+            0x8000..=0x9fff => match self.ram_bank {
+                Some(ref mut ram) => ram.write_bytes_relative(addr, data),
+                None => {},
+            },
+        })
     }
 }
 
@@ -636,20 +695,32 @@ impl Mbc1Rom {
 }
 
 impl MemDevice for Mbc1Rom {
-    fn read(&self, addr: Addr) -> u8 {
-        match addr.relative() {
-            0..=0x3fff => self.lower_bank().read(addr),
-            0x4000..=0x7fff => self.upper_bank().read(addr.offset_by(0x4000)),
+    const LEN: usize = CART_MEMDEV_LEN;
+
+    fn read_byte_relative(&self, addr: RelativeAddr) -> u8 {
+        dispatch_memdev_byte!(Mbc1Rom, addr, |addr| {
+            0..=0x3fff => self.lower_bank().read_byte_relative(addr),
+            0x4000..=0x7fff => self.upper_bank().read_byte_relative(addr),
             0x8000..=0x9fff => match self.ram_bank() {
-                Some(bank) => bank.read(addr.offset_by(0x8000)),
-                None => 0,
+                Some(bank) => bank.read_byte_relative(addr),
+                None => 0xff,
             },
-            _ => panic!("Address {} out of range for Mbc1Rom", addr),
-        }
+        })
     }
 
-    fn write(&mut self, addr: Addr, value: u8) {
-        match addr.relative() {
+    fn read_bytes_relative(&self, addr: RelativeAddr, data: &mut [u8]) {
+        dispatch_memdev_bytes!(Mbc1Rom, addr, data, |addr, mut data| {
+            0..=0x3fff => self.lower_bank().read_bytes_relative(addr, data),
+            0x4000..=0x7fff => self.upper_bank().read_bytes_relative(addr, data),
+            0x8000..=0x9fff => match self.ram_bank() {
+                Some(bank) => bank.read_bytes_relative(addr, data),
+                None => data.fill(0xff),
+            },
+        })
+    }
+
+    fn write_byte_relative(&mut self, addr: RelativeAddr, value: u8) {
+        dispatch_memdev_byte!(Mbc1Rom, addr, |addr| {
             0x0000..=0x1fff => self.ram_enable = (value & 0xF) == 0xA,
             // Set the low-order bits of the rom-bank selection from the lower 5 bits of the
             // provided value. If 0 is provided, raise the value to 1.
@@ -660,11 +731,47 @@ impl MemDevice for Mbc1Rom {
             // Change between basic and advanced banking mode.
             0x6000..=0x7fff => self.advanced_banking_mode = (value & 1) != 0,
             0x8000..=0x9fff => match self.ram_bank_mut() {
-                Some(bank) => bank.write(addr.offset_by(0x8000), value),
+                Some(bank) => bank.write_byte_relative(addr, value),
                 None => {}
             },
-            _ => panic!("Address {} out of range for Mbc1Rom", addr),
-        }
+        })
+    }
+
+    fn write_bytes_relative(&mut self, addr: RelativeAddr, data: &[u8]) {
+        // Writes to the control registers are applied as if all the bytes in the range
+        // were written in order, so only the last byte in each control register range
+        // counts.
+        dispatch_memdev_bytes!(Mbc1Rom, addr, data, |addr, ref data| {
+            0x0000..=0x1fff => {
+                let value = data.last()
+                    .expect("dispatch_range should never provide an empty range");
+                self.ram_enable = (value & 0xF) == 0xA;
+            },
+            // Set the low-order bits of the rom-bank selection from the lower 5 bits of the
+            // provided value. If 0 is provided, raise the value to 1.
+            0x2000..=0x3fff => {
+                let value = data.last()
+                    .expect("dispatch_range should never provide an empty range");
+                self.rom_bank = NonZeroU8::new((value & 0x1f).max(1)).unwrap();
+            },
+            // Take the 3 bottom bits as the bank set. These will be applied based on whether the
+            // mode is ram mode or rom mode when used.
+            0x4000..=0x5fff => {
+                let value = data.last()
+                    .expect("dispatch_range should never provide an empty range");
+                self.bank_set = value & 0x3;
+            },
+            // Change between basic and advanced banking mode.
+            0x6000..=0x7fff => {
+                let value = data.last()
+                    .expect("dispatch_range should never provide an empty range");
+                self.advanced_banking_mode = (value & 1) != 0;
+            },
+            0x8000..=0x9fff => match self.ram_bank_mut() {
+                Some(bank) => bank.write_bytes_relative(addr, data),
+                None => {}
+            },
+        })
     }
 }
 
@@ -888,21 +995,34 @@ impl Mbc3Rom {
 }
 
 impl MemDevice for Mbc3Rom {
-    fn read(&self, addr: Addr) -> u8 {
-        match addr.relative() {
-            0..=0x3fff => self.lower_bank().read(addr),
-            0x4000..=0x7fff => self.upper_bank().read(addr.offset_by(0x4000)),
+    const LEN: usize = CART_MEMDEV_LEN;
+
+    fn read_byte_relative(&self, addr: RelativeAddr) -> u8 {
+        dispatch_memdev_byte!(Mbc3Rom, addr, |addr| {
+            0..=0x3fff => self.lower_bank().read_byte_relative(addr),
+            0x4000..=0x7fff => self.upper_bank().read_byte_relative(addr),
             0x8000..=0x9fff => match self.ram_rtc_bank() {
-                RamOrRtc::Ram(bank) => bank.read(addr.offset_by(0x8000)),
+                RamOrRtc::Ram(bank) => bank.read_byte_relative(addr),
                 RamOrRtc::Rtc(reg) => *reg,
-                RamOrRtc::None => 0,
+                RamOrRtc::None => 0xff,
             },
-            _ => panic!("Address {} out of range for Mbc3Rom", addr),
-        }
+        })
     }
 
-    fn write(&mut self, addr: Addr, value: u8) {
-        match addr.relative() {
+    fn read_bytes_relative(&self, addr: RelativeAddr, data: &mut [u8]) {
+        dispatch_memdev_bytes!(Mbc3Rom, addr, data, |addr, mut data| {
+            0..=0x3fff => self.lower_bank().read_bytes_relative(addr, data),
+            0x4000..=0x7fff => self.upper_bank().read_bytes_relative(addr, data),
+            0x8000..=0x9fff => match self.ram_rtc_bank() {
+                RamOrRtc::Ram(bank) => bank.read_bytes_relative(addr, data),
+                RamOrRtc::Rtc(reg) => data.fill(*reg),
+                RamOrRtc::None => data.fill(0xff),
+            },
+        })
+    }
+
+    fn write_byte_relative(&mut self, addr: RelativeAddr, value: u8) {
+        dispatch_memdev_byte!(Mbc3Rom, addr, |addr| {
             0x0000..=0x1fff => self.ram_enable = (value & 0xF) == 0xA,
             // Set the low-order bits of the rom-bank selection from the lower 5 bits of the
             // provided value. If 0 is provided, raise the value to 1.
@@ -913,12 +1033,50 @@ impl MemDevice for Mbc3Rom {
             // Change between basic and advanced banking mode.
             0x6000..=0x7fff => self.rtc_latch = (value & 1) != 0,
             0x8000..=0x9fff => match self.ram_rtc_bank_mut() {
-                RamOrRtc::Ram(bank) => bank.write(addr.offset_by(0x8000), value),
+                RamOrRtc::Ram(bank) => bank.write_byte_relative(addr, value),
                 RamOrRtc::Rtc(reg) => *reg = value,
                 RamOrRtc::None => {}
             },
-            _ => panic!("Address {} out of range for Mbc3Rom", addr),
-        }
+        })
+    }
+
+    fn write_bytes_relative(&mut self, addr: RelativeAddr, data: &[u8]) {
+        dispatch_memdev_bytes!(Mbc3Rom, addr, data, |addr, ref data| {
+            0x0000..=0x1fff => {
+                let value = data.last()
+                    .expect("dispatch_range should never provide an empty range");
+                self.ram_enable = (value & 0xF) == 0xA
+            },
+            // Set the low-order bits of the rom-bank selection from the lower 5 bits of the
+            // provided value. If 0 is provided, raise the value to 1.
+            0x2000..=0x3fff => {
+                let value = data.last()
+                    .expect("dispatch_range should never provide an empty range");
+                self.rom_bank = value & 0x7f
+            },
+            // Take the 3 bottom bits as the bank set. These will be applied based on whether the
+            // mode is ram mode or rom mode when used.
+            0x4000..=0x5fff => {
+                let value = data.last()
+                    .expect("dispatch_range should never provide an empty range");
+                self.bank_set = value & 0x3
+            },
+            // Change between basic and advanced banking mode.
+            0x6000..=0x7fff => {
+                let value = data.last()
+                    .expect("dispatch_range should never provide an empty range");
+                self.rtc_latch = (value & 1) != 0
+            },
+            0x8000..=0x9fff => match self.ram_rtc_bank_mut() {
+                RamOrRtc::Ram(bank) => bank.write_bytes_relative(addr, data),
+                RamOrRtc::Rtc(reg) => {
+                    let value = data.last()
+                        .expect("dispatch_range should never provide an empty range");
+                    *reg = *value
+                },
+                RamOrRtc::None => {}
+            },
+        })
     }
 }
 
@@ -942,5 +1100,202 @@ impl SaveData for Mbc3Rom {
 
     fn has_save_data(&self) -> bool {
         self.save_ram
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem;
+
+    use super::*;
+
+    use rand::distributions::Uniform;
+    use rand::{Rng, SeedableRng};
+    use rand_pcg::Pcg64Mcg;
+
+    fn init() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
+    #[test]
+    fn romonly_range_readwrite() {
+        init();
+
+        let mut rom_banks = Box::new([ReadOnly([0u8; ROM_BANK_SIZE]); 2]);
+        let mut ram_bank = Box::new([0u8; RAM_BANK_SIZE]);
+
+        // Pre-fill memory with unique values.
+        let mut nextval = 0u32;
+        for bank in rom_banks.iter_mut() {
+            for chunk in bank.0.chunks_exact_mut(mem::size_of_val(&nextval)) {
+                chunk.copy_from_slice(nextval.to_le_bytes().as_ref());
+                nextval += 1;
+            }
+        }
+        for chunk in ram_bank.chunks_exact_mut(mem::size_of_val(&nextval)) {
+            chunk.copy_from_slice(nextval.to_le_bytes().as_ref());
+            nextval += 1;
+        }
+
+        let mut cart_individual = RomOnly::new(rom_banks, Some(ram_bank), false);
+        let mut cart_slice = cart_individual.clone();
+
+        let mut input_buf = vec![];
+        let mut output_buf_individual = vec![];
+        let mut output_buf_slice = vec![];
+        let mut rng =
+            Pcg64Mcg::from_seed([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF]);
+
+        let len_dist = Uniform::new_inclusive(1, 0x400);
+
+        assert_eq!(cart_individual, cart_slice);
+
+        for _ in 0..0x80000 {
+            let len = rng.sample(&len_dist);
+
+            let addr_dist = Uniform::new(0, CART_MEMDEV_LEN - len);
+            let addr: RelativeAddr = (rng.sample(&addr_dist) as u16).into();
+            input_buf.resize(len, 0u8);
+            rng.fill(&mut input_buf[..]);
+
+            for (i, &val) in input_buf.iter().enumerate() {
+                cart_individual.write_byte_relative(addr.move_forward_by(i as u16), val);
+            }
+            cart_slice.write_bytes_relative(addr, &input_buf);
+
+            output_buf_individual.resize(len, 0u8);
+            for (i, res) in output_buf_individual.iter_mut().enumerate() {
+                *res = cart_individual.read_byte_relative(addr.move_forward_by(i as u16));
+            }
+            output_buf_slice.resize(len, 0u8);
+            cart_slice.read_bytes_relative(addr, &mut output_buf_slice);
+
+            assert_eq!(output_buf_individual, output_buf_slice);
+        }
+
+        // To reduce the test runtime, only compare the final result.
+        assert_eq!(cart_individual, cart_slice);
+    }
+
+    #[test]
+    fn mbc1_range_readwrite() {
+        init();
+
+        let mut cart = Mbc1Rom::new(vec![ReadOnly([0u8; ROM_BANK_SIZE]); 128], 4, false);
+
+        // Pre-fill memory with unique values.
+        let mut nextval = 0u32;
+        for bank in cart.rom_banks.iter_mut() {
+            for chunk in bank.0.chunks_exact_mut(mem::size_of_val(&nextval)) {
+                chunk.copy_from_slice(nextval.to_le_bytes().as_ref());
+                nextval += 1;
+            }
+        }
+        for bank in cart.ram_banks.iter_mut() {
+            for chunk in bank.chunks_exact_mut(mem::size_of_val(&nextval)) {
+                chunk.copy_from_slice(nextval.to_le_bytes().as_ref());
+                nextval += 1;
+            }
+        }
+
+        let mut cart_individual = cart.clone();
+        let mut cart_slice = cart;
+
+        let mut input_buf = vec![];
+        let mut output_buf_individual = vec![];
+        let mut output_buf_slice = vec![];
+        let mut rng =
+            Pcg64Mcg::from_seed([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF]);
+
+        let len_dist = Uniform::new_inclusive(1, 0x400);
+
+        assert_eq!(cart_individual, cart_slice);
+
+        for _ in 0..0x80000 {
+            let len = rng.sample(&len_dist);
+
+            let addr_dist = Uniform::new(0, CART_MEMDEV_LEN - len);
+            let addr: RelativeAddr = (rng.sample(&addr_dist) as u16).into();
+            input_buf.resize(len, 0u8);
+            rng.fill(&mut input_buf[..]);
+
+            for (i, &val) in input_buf.iter().enumerate() {
+                cart_individual.write_byte_relative(addr.move_forward_by(i as u16), val);
+            }
+            cart_slice.write_bytes_relative(addr, &input_buf);
+
+            output_buf_individual.resize(len, 0u8);
+            for (i, res) in output_buf_individual.iter_mut().enumerate() {
+                *res = cart_individual.read_byte_relative(addr.move_forward_by(i as u16));
+            }
+            output_buf_slice.resize(len, 0u8);
+            cart_slice.read_bytes_relative(addr, &mut output_buf_slice);
+
+            assert_eq!(output_buf_individual, output_buf_slice);
+        }
+
+        // To reduce the test runtime, only compare the final result.
+        assert_eq!(cart_individual, cart_slice);
+    }
+
+    #[test]
+    fn mbc3_range_readwrite() {
+        init();
+
+        let mut cart = Mbc3Rom::new(vec![ReadOnly([0u8; ROM_BANK_SIZE]); 128], 4, false);
+
+        // Pre-fill memory with unique values.
+        let mut nextval = 0u32;
+        for bank in cart.rom_banks.iter_mut() {
+            for chunk in bank.0.chunks_exact_mut(mem::size_of_val(&nextval)) {
+                chunk.copy_from_slice(nextval.to_le_bytes().as_ref());
+                nextval += 1;
+            }
+        }
+        for bank in cart.ram_banks.iter_mut() {
+            for chunk in bank.chunks_exact_mut(mem::size_of_val(&nextval)) {
+                chunk.copy_from_slice(nextval.to_le_bytes().as_ref());
+                nextval += 1;
+            }
+        }
+
+        let mut cart_individual = cart.clone();
+        let mut cart_slice = cart;
+
+        let mut input_buf = vec![];
+        let mut output_buf_individual = vec![];
+        let mut output_buf_slice = vec![];
+        let mut rng =
+            Pcg64Mcg::from_seed([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF]);
+
+        let len_dist = Uniform::new_inclusive(1, 0x400);
+
+        assert_eq!(cart_individual, cart_slice);
+
+        for _ in 0..0x80000 {
+            let len = rng.sample(&len_dist);
+
+            let addr_dist = Uniform::new(0, CART_MEMDEV_LEN - len);
+            let addr: RelativeAddr = (rng.sample(&addr_dist) as u16).into();
+            input_buf.resize(len, 0u8);
+            rng.fill(&mut input_buf[..]);
+
+            for (i, &val) in input_buf.iter().enumerate() {
+                cart_individual.write_byte_relative(addr.move_forward_by(i as u16), val);
+            }
+            cart_slice.write_bytes_relative(addr, &input_buf);
+
+            output_buf_individual.resize(len, 0u8);
+            for (i, res) in output_buf_individual.iter_mut().enumerate() {
+                *res = cart_individual.read_byte_relative(addr.move_forward_by(i as u16));
+            }
+            output_buf_slice.resize(len, 0u8);
+            cart_slice.read_bytes_relative(addr, &mut output_buf_slice);
+
+            assert_eq!(output_buf_individual, output_buf_slice);
+        }
+
+        // To reduce the test runtime, only compare the final result.
+        assert_eq!(cart_individual, cart_slice);
     }
 }

--- a/feo3boy/src/serial.rs
+++ b/feo3boy/src/serial.rs
@@ -79,12 +79,10 @@ pub struct SerialRegs {
     pub serial_control: u8,
 }
 
-memdev_fields! {
-    SerialRegs {
-        0x00 => serial_data,
-        0x01 => serial_control,
-    }
-}
+memdev_fields!(SerialRegs, len: 2, {
+    0x00 => serial_data,
+    0x01 => serial_control,
+});
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct SerialState {

--- a/web-debugger/src/derefs.rs
+++ b/web-debugger/src/derefs.rs
@@ -1,5 +1,5 @@
 use feo3boy::gb::Gb;
-use feo3boy::memdev::MemDevice;
+use feo3boy::memdev::RootMemDevice;
 use yew::prelude::*;
 
 use crate::instrs::{Instr, InstrInfo};
@@ -23,14 +23,11 @@ pub struct ComputedDerefs {
 impl From<&Gb> for ComputedDerefs {
     fn from(gb: &Gb) -> Self {
         Self {
-            pbc: gb.mmu.read(gb.cpustate.regs.bc().into()),
-            pde: gb.mmu.read(gb.cpustate.regs.de().into()),
-            phl: gb.mmu.read(gb.cpustate.regs.hl().into()),
-            pffc: gb.mmu.read((0xff00 + gb.cpustate.regs.c as u16).into()),
-            psp: u16::from_le_bytes([
-                gb.mmu.read(gb.cpustate.regs.sp.into()),
-                gb.mmu.read(gb.cpustate.regs.sp.wrapping_add(1).into()),
-            ]),
+            pbc: gb.mmu.read(gb.cpustate.regs.bc()),
+            pde: gb.mmu.read(gb.cpustate.regs.de()),
+            phl: gb.mmu.read(gb.cpustate.regs.hl()),
+            pffc: gb.mmu.read(0xff00 + gb.cpustate.regs.c as u16),
+            psp: gb.mmu.read(gb.cpustate.regs.sp),
             ppc: InstrInfo::fetch_at(&gb.mmu, gb.cpustate.regs.pc),
         }
     }

--- a/web-debugger/src/instrs.rs
+++ b/web-debugger/src/instrs.rs
@@ -1,4 +1,4 @@
-use feo3boy::memdev::MemDevice;
+use feo3boy::memdev::RootMemDevice;
 use feo3boy_opcodes::opcode::args::{ConditionCode, Operand16, Operand8};
 use feo3boy_opcodes::opcode::{CBOpcode, Opcode};
 use yew::prelude::*;
@@ -14,13 +14,10 @@ pub struct InstrInfo {
 }
 
 impl InstrInfo {
-    pub fn fetch_at(mem: &impl MemDevice, addr: u16) -> Self {
+    pub fn fetch_at(mem: &impl RootMemDevice, addr: u16) -> Self {
         Self {
-            opcode: Opcode::decode(mem.read(addr.into())),
-            imm: [
-                mem.read(addr.wrapping_add(1).into()),
-                mem.read(addr.wrapping_add(2).into()),
-            ],
+            opcode: Opcode::decode(mem.read(addr)),
+            imm: mem.read(addr.wrapping_add(1)),
         }
     }
 

--- a/web-debugger/src/memview/mod.rs
+++ b/web-debugger/src/memview/mod.rs
@@ -288,10 +288,25 @@ pub fn view_io(props: &ViewIoProps) -> Html {
             {named("LYC")}
             <span class="byte">{hexbyte(props.io.ppu_regs.lcdc_y_compare)}</span>
         </div>
-        <div class="line unimplemented">
+        <div class="line">
             {addr(0xff46)}
-            {named("DMA")}
-            <span class="byte">{hexbyte(props.io.ppu_regs.dma_addr)}</span>
+            {named("DMA (base)")}
+            <span class="byte">{hex16(props.io.ppu_regs.dma.base_addr())}</span>
+        </div>
+        <div class="line">
+            {addr(0xff46)}
+            {named("DMA (active)")}
+            <span>{props.io.ppu_regs.dma.active()}</span>
+        </div>
+        <div class="line">
+            {addr(0xff46)}
+            {named("DMA (source)")}
+            <span>{hex16(props.io.ppu_regs.dma.source_addr())}</span>
+        </div>
+        <div class="line">
+            {addr(0xff46)}
+            {named("DMA (dest)")}
+            <span>{hex16(props.io.ppu_regs.dma.dest_addr().raw())}</span>
         </div>
         <div class="line">
             {addr(0xff47)}


### PR DESCRIPTION
Add methods to MemDevice to read/write an entire block of memory in one step. The slice of bytes read must fit entirely within the MemDevice without wrapping. To facilitate reads/writes with wrapping, create a new type called RootMemDevice which can read any u16 address and which allows reading to slices which overflow/wrap.

Using this, add a feature to read/write arbitrary types to/from memory and use that feature for a few places that want to read multiple bytes, e.g. u16 and Object.